### PR TITLE
Ensure SYMTAB in rlib's with arch code but no syms

### DIFF
--- a/src/archive_writer.rs
+++ b/src/archive_writer.rs
@@ -408,12 +408,17 @@ fn write_symbols(
     has_object: &mut bool,
 ) -> io::Result<Vec<u64>> {
     let mut ret = vec![];
-    *has_object = get_symbols(buf, &mut |sym| {
+    // We only set has_object if get_symbols determines it's looking at an
+    // object file. This is because if we're creating an rlib, the archive will
+    // always end in lib.rmeta, and cause has_object to always become false.
+    if get_symbols(buf, &mut |sym| {
         ret.push(sym_names.stream_position()?);
         sym_names.write_all(sym)?;
         sym_names.write_all(&[0])?;
         Ok(())
-    })?;
+    })? {
+        *has_object = true;
+    }
     Ok(ret)
 }
 


### PR DESCRIPTION
I was experimenting with using no_std and rustc_codegen_gcc, and it mostly works great, except that librustc_std_workspace_core.rlib would cause a linker error, as GNU LD couldn't find a symbol table for the archive. Investigating it seems to have uncovered an oversight, has_object will effectively inevitably always get reset back to false once it hits the lib.rmeta file, which causes a problem if there's also no symbols pulled out of any of the interior object files (this happens if get_native_object_symbols doesn't see any global symbols prior to lib.rmeta). The rest of the code following will incorrectly assume that since there's no symbols, there must not be any objects inside, and thus no need for a SYMTAB.

![Screenshot 2023-03-21 232658](https://user-images.githubusercontent.com/29870961/227073016-7bfa6707-f2c6-4c48-bc65-cebb84b0a9d5.png)
