### PR TITLE
Removed unused options (deterministic, symbol table)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ar_archive_writer"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A writer for object file ar archives"

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,10 @@
 # A writer for object file ar archives
 
-This is based on commit [8ef3e895a](https://github.com/llvm/llvm-project/tree/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2) (15.0.0-rc3) of LLVM's archive writer.
+This is a Rust port of LLVM's archive writer (`ArchiveWriter.cpp`):
+* Based on commit [8ef3e895a](https://github.com/llvm/llvm-project/tree/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2) (15.0.0-rc3).
+* With the following options removed:
+  * Deterministic: always enabled.
+  * Symbol tables: always enabled.
 
 ## License
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -97,15 +97,8 @@ pub fn create_archive_with_ar_archive_writer<'a>(
         })
         .collect::<Vec<_>>();
     let mut output_bytes = Cursor::new(Vec::new());
-    ar_archive_writer::write_archive_to_stream(
-        &mut output_bytes,
-        &members,
-        true,
-        archive_kind,
-        true,
-        false,
-    )
-    .unwrap();
+    ar_archive_writer::write_archive_to_stream(&mut output_bytes, &members, archive_kind, false)
+        .unwrap();
 
     let output_archive_bytes = output_bytes.into_inner();
     let ar_archive_writer_file_path = tmpdir.join("output_ar_archive_writer.a");


### PR DESCRIPTION
The Rust compiler always sets deterministic and enables symbol tables therefore, to simplify both the code and tests, they are the only options that will be supported.

Note that this will make syncing to the latest LLVM sources a bit more difficult, but it shouldn't be too bad since it doesn't significantly change the shape of the code.