### PR TITLE
Add tests for thin archives, fix bugs found in testing

### DIFF
--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -25,6 +25,7 @@ fn round_trip_and_diff(
         &tmpdir,
         archive_kind,
         [("input.o", input_bytes.as_slice())],
+        false,
     );
 
     // Read the archive and member using object and diff with original data.
@@ -50,6 +51,7 @@ fn round_trip_and_diff(
         &tmpdir,
         archive_kind,
         [("input.o", input_bytes.as_slice())],
+        false,
     );
     assert_eq!(
         output_archive_bytes, output_llvm_ar_bytes,


### PR DESCRIPTION
Add tests for thin archives and fixes two bugs where we were using the `data` local (which is empty for thin archives) instead of the original buffer when writing the size of each member and searching for symbols.