### PR TITLE
Sync to LLVM 18.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,14 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      RUSTFLAGS: -Dwarnings
+      RUST_BACKTRACE: full
     steps:
       - uses: actions/checkout@v3
+      - name: Clippy
+        run: |
+          cargo clippy -- -Dwarnings
       - name: Test
         run: |
           cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ar_archive_writer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A writer for object file ar archives"
@@ -11,9 +11,9 @@ repository = "https://github.com/rust-lang/ar_archive_writer"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-object = { version = "0.32.0", default-features = false, features = ["std", "read"] }
+object = { version = "0.35.0", default-features = false, features = ["std", "read"] }
 
 [dev-dependencies]
 cargo-binutils = "0.3.6"
-object = { version = "0.32.0", default-features = false, features = ["write", "xcoff"] }
+object = { version = "0.35.0", default-features = false, features = ["write", "xcoff"] }
 pretty_assertions = "1.4.0"

--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,9 @@
 # A writer for object file ar archives
 
-This is a Rust port of LLVM's archive writer (`ArchiveWriter.cpp`):
-* Based on commit [8ef3e895a](https://github.com/llvm/llvm-project/tree/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2) (15.0.0-rc3).
-* With the following options removed:
-  * Deterministic: always enabled.
-  * Symbol tables: always enabled.
+This is a Rust port of LLVM's archive writer (see [the LLVM Reference](reference/Readme.md)
+for details) with the following options removed:
+* Deterministic: always enabled.
+* Symbol tables: always enabled.
 
 ## License
 

--- a/reference/Alignment.h
+++ b/reference/Alignment.h
@@ -21,9 +21,9 @@
 #ifndef LLVM_SUPPORT_ALIGNMENT_H_
 #define LLVM_SUPPORT_ALIGNMENT_H_
 
-#include "llvm/ADT/Optional.h"
 #include "llvm/Support/MathExtras.h"
 #include <cassert>
+#include <optional>
 #ifndef NDEBUG
 #include <string>
 #endif // NDEBUG
@@ -93,14 +93,14 @@ public:
   }
 
   /// Allow constructions of constexpr Align.
-  template <size_t kValue> constexpr static LogValue Constant() {
+  template <size_t kValue> constexpr static Align Constant() {
     return LogValue{static_cast<uint8_t>(CTLog2<kValue>())};
   }
 
   /// Allow constructions of constexpr Align from types.
   /// Compile time equivalent to Align(alignof(T)).
-  template <typename T> constexpr static LogValue Of() {
-    return Constant<std::alignment_of<T>::value>();
+  template <typename T> constexpr static Align Of() {
+    return Constant<std::alignment_of_v<T>>();
   }
 
   /// Constexpr constructor from LogValue type.
@@ -114,9 +114,9 @@ inline Align assumeAligned(uint64_t Value) {
 
 /// This struct is a compact representation of a valid (power of two) or
 /// undefined (0) alignment.
-struct MaybeAlign : public llvm::Optional<Align> {
+struct MaybeAlign : public std::optional<Align> {
 private:
-  using UP = llvm::Optional<Align>;
+  using UP = std::optional<Align>;
 
 public:
   /// Default is undefined.
@@ -128,9 +128,8 @@ public:
   MaybeAlign(MaybeAlign &&Other) = default;
   MaybeAlign &operator=(MaybeAlign &&Other) = default;
 
-  /// Use llvm::Optional<Align> constructor.
-  using UP::UP;
-
+  constexpr MaybeAlign(std::nullopt_t None) : UP(None) {}
+  constexpr MaybeAlign(Align Value) : UP(Value) {}
   explicit MaybeAlign(uint64_t Value) {
     assert((Value == 0 || llvm::isPowerOf2_64(Value)) &&
            "Alignment is neither 0 nor a power of 2");
@@ -291,6 +290,22 @@ bool operator<=(MaybeAlign Lhs, MaybeAlign Rhs) = delete;
 bool operator>=(MaybeAlign Lhs, MaybeAlign Rhs) = delete;
 bool operator<(MaybeAlign Lhs, MaybeAlign Rhs) = delete;
 bool operator>(MaybeAlign Lhs, MaybeAlign Rhs) = delete;
+
+// Allow equality comparisons between Align and MaybeAlign.
+inline bool operator==(MaybeAlign Lhs, Align Rhs) { return Lhs && *Lhs == Rhs; }
+inline bool operator!=(MaybeAlign Lhs, Align Rhs) { return !(Lhs == Rhs); }
+inline bool operator==(Align Lhs, MaybeAlign Rhs) { return Rhs == Lhs; }
+inline bool operator!=(Align Lhs, MaybeAlign Rhs) { return !(Rhs == Lhs); }
+// Allow equality comparisons with MaybeAlign.
+inline bool operator==(MaybeAlign Lhs, MaybeAlign Rhs) {
+  return (Lhs && Rhs && (*Lhs == *Rhs)) || (!Lhs && !Rhs);
+}
+inline bool operator!=(MaybeAlign Lhs, MaybeAlign Rhs) { return !(Lhs == Rhs); }
+// Allow equality comparisons with std::nullopt.
+inline bool operator==(MaybeAlign Lhs, std::nullopt_t) { return !bool(Lhs); }
+inline bool operator!=(MaybeAlign Lhs, std::nullopt_t) { return bool(Lhs); }
+inline bool operator==(std::nullopt_t, MaybeAlign Rhs) { return !bool(Rhs); }
+inline bool operator!=(std::nullopt_t, MaybeAlign Rhs) { return bool(Rhs); }
 
 #ifndef NDEBUG
 // For usage in LLVM_DEBUG macros.

--- a/reference/Alignment.h
+++ b/reference/Alignment.h
@@ -1,5 +1,3 @@
-// Copied from https://github.com/llvm/llvm-project/blob/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2/llvm/include/llvm/Support/Alignment.h
-
 //===-- llvm/Support/Alignment.h - Useful alignment functions ---*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/reference/Archive.h
+++ b/reference/Archive.h
@@ -28,9 +28,6 @@
 #include <vector>
 
 namespace llvm {
-
-template <typename T> class Optional;
-
 namespace object {
 
 const char ArchiveMagic[] = "!<arch>\n";
@@ -305,6 +302,7 @@ public:
     StringRef getName() const;
     Expected<Child> getMember() const;
     Symbol getNext() const;
+    bool isECSymbol() const;
   };
 
   class symbol_iterator {
@@ -355,16 +353,19 @@ public:
     return make_range(symbol_begin(), symbol_end());
   }
 
+  Expected<iterator_range<symbol_iterator>> ec_symbols() const;
+
   static bool classof(Binary const *v) { return v->isArchive(); }
 
   // check if a symbol is in the archive
-  Expected<Optional<Child>> findSym(StringRef name) const;
+  Expected<std::optional<Child>> findSym(StringRef name) const;
 
   virtual bool isEmpty() const;
   bool hasSymbolTable() const;
   StringRef getSymbolTable() const { return SymbolTable; }
   StringRef getStringTable() const { return StringTable; }
   uint32_t getNumberOfSymbols() const;
+  uint32_t getNumberOfECSymbols() const;
   virtual uint64_t getFirstChildOffset() const { return getArchiveMagicLen(); }
 
   std::vector<std::unique_ptr<MemoryBuffer>> takeThinBuffers() {
@@ -380,6 +381,7 @@ protected:
   void setFirstRegular(const Child &C);
 
   StringRef SymbolTable;
+  StringRef ECSymbolTable;
   StringRef StringTable;
 
 private:
@@ -408,14 +410,18 @@ public:
   const FixLenHdr *ArFixLenHdr;
   uint64_t FirstChildOffset = 0;
   uint64_t LastChildOffset = 0;
+  std::string MergedGlobalSymtabBuf;
+  bool Has32BitGlobalSymtab = false;
+  bool Has64BitGlobalSymtab = false;
 
 public:
   BigArchive(MemoryBufferRef Source, Error &Err);
   uint64_t getFirstChildOffset() const override { return FirstChildOffset; }
   uint64_t getLastChildOffset() const { return LastChildOffset; }
-  bool isEmpty() const override {
-    return Data.getBufferSize() == sizeof(FixLenHdr);
-  };
+  bool isEmpty() const override { return getFirstChildOffset() == 0; }
+
+  bool has32BitGlobalSymtab() { return Has32BitGlobalSymtab; }
+  bool has64BitGlobalSymtab() { return Has64BitGlobalSymtab; }
 };
 
 } // end namespace object

--- a/reference/Archive.h
+++ b/reference/Archive.h
@@ -1,5 +1,3 @@
-// Copied from https://github.com/llvm/llvm-project/blob/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2/llvm/include/llvm/Object/Archive.h
-
 //===- Archive.h - ar archive file format -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/reference/ArchiveWriter.cpp
+++ b/reference/ArchiveWriter.cpp
@@ -17,6 +17,8 @@
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Object/Archive.h"
+#include "llvm/Object/COFF.h"
+#include "llvm/Object/COFFImportFile.h"
 #include "llvm/Object/Error.h"
 #include "llvm/Object/IRObjectFile.h"
 #include "llvm/Object/MachO.h"
@@ -33,6 +35,7 @@
 #include "llvm/Support/SmallVectorMemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cerrno>
 #include <map>
 
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
@@ -42,6 +45,13 @@
 #endif
 
 using namespace llvm;
+using namespace llvm::object;
+
+struct SymMap {
+  bool UseECMap;
+  std::map<std::string, uint16_t> Map;
+  std::map<std::string, uint16_t> ECMap;
+};
 
 NewArchiveMember::NewArchiveMember(MemoryBufferRef BufRef)
     : Buf(MemoryBuffer::getMemBuffer(BufRef, false)),
@@ -69,9 +79,11 @@ object::Archive::Kind NewArchiveMember::detectKindFromObject() const {
     if (auto ObjOrErr = object::SymbolicFile::createSymbolicFile(
             MemBufferRef, file_magic::bitcode, &Context)) {
       auto &IRObject = cast<object::IRObjectFile>(**ObjOrErr);
-      return Triple(IRObject.getTargetTriple()).isOSDarwin()
+      auto TargetTriple = Triple(IRObject.getTargetTriple());
+      return TargetTriple.isOSDarwin()
                  ? object::Archive::K_DARWIN
-                 : object::Archive::K_GNU;
+                 : (TargetTriple.isOSAIX() ? object::Archive::K_AIXBIG
+                                           : object::Archive::K_GNU);
     } else {
       // Squelch the error in case this was not a SymbolicFile.
       consumeError(ObjOrErr.takeError());
@@ -169,18 +181,21 @@ static bool isAIXBigArchive(object::Archive::Kind Kind) {
   return Kind == object::Archive::K_AIXBIG;
 }
 
+static bool isCOFFArchive(object::Archive::Kind Kind) {
+  return Kind == object::Archive::K_COFF;
+}
+
 static bool isBSDLike(object::Archive::Kind Kind) {
   switch (Kind) {
   case object::Archive::K_GNU:
   case object::Archive::K_GNU64:
   case object::Archive::K_AIXBIG:
+  case object::Archive::K_COFF:
     return false;
   case object::Archive::K_BSD:
   case object::Archive::K_DARWIN:
   case object::Archive::K_DARWIN64:
     return true;
-  case object::Archive::K_COFF:
-    break;
   }
   llvm_unreachable("not supported for writting");
 }
@@ -188,7 +203,12 @@ static bool isBSDLike(object::Archive::Kind Kind) {
 template <class T>
 static void print(raw_ostream &Out, object::Archive::Kind Kind, T Val) {
   support::endian::write(Out, Val,
-                         isBSDLike(Kind) ? support::little : support::big);
+                         isBSDLike(Kind) ? llvm::endianness::little
+                                         : llvm::endianness::big);
+}
+
+template <class T> static void printLE(raw_ostream &Out, T Val) {
+  support::endian::write(Out, Val, llvm::endianness::little);
 }
 
 static void printRestOfMemberHeader(
@@ -235,8 +255,8 @@ static void
 printBigArchiveMemberHeader(raw_ostream &Out, StringRef Name,
                             const sys::TimePoint<std::chrono::seconds> &ModTime,
                             unsigned UID, unsigned GID, unsigned Perms,
-                            uint64_t Size, unsigned PrevOffset,
-                            unsigned NextOffset) {
+                            uint64_t Size, uint64_t PrevOffset,
+                            uint64_t NextOffset) {
   unsigned NameLen = Name.size();
 
   printWithSpacePadding(Out, Size, 20);           // File member size
@@ -295,7 +315,11 @@ printMemberHeader(raw_ostream &Out, uint64_t Pos, raw_ostream &StringTable,
     auto Insertion = MemberNames.insert({M.MemberName, uint64_t(0)});
     if (Insertion.second) {
       Insertion.first->second = StringTable.tell();
-      StringTable << M.MemberName << "/\n";
+      StringTable << M.MemberName;
+      if (isCOFFArchive(Kind))
+        StringTable << '\0';
+      else
+        StringTable << "/\n";
     }
     NamePos = Insertion.first->second;
   }
@@ -309,6 +333,8 @@ struct MemberData {
   std::string Header;
   StringRef Data;
   StringRef Padding;
+  uint64_t PreHeadPadSize = 0;
+  std::unique_ptr<SymbolicFile> SymFile = nullptr;
 };
 } // namespace
 
@@ -356,7 +382,7 @@ static void printNBits(raw_ostream &Out, object::Archive::Kind Kind,
 
 static uint64_t computeSymbolTableSize(object::Archive::Kind Kind,
                                        uint64_t NumSyms, uint64_t OffsetSize,
-                                       StringRef StringTable,
+                                       uint64_t StringTableSize,
                                        uint32_t *Padding = nullptr) {
   assert((OffsetSize == 4 || OffsetSize == 8) && "Unsupported OffsetSize");
   uint64_t Size = OffsetSize; // Number of entries
@@ -366,7 +392,7 @@ static uint64_t computeSymbolTableSize(object::Archive::Kind Kind,
     Size += NumSyms * OffsetSize; // Table
   if (isBSDLike(Kind))
     Size += OffsetSize; // byte count
-  Size += StringTable.size();
+  Size += StringTableSize;
   // ld64 expects the members to be 8-byte aligned for 64-bit content and at
   // least 4-byte aligned for 32-bit content.  Opt for the larger encoding
   // uniformly.
@@ -376,6 +402,36 @@ static uint64_t computeSymbolTableSize(object::Archive::Kind Kind,
   uint32_t Pad = isAIXBigArchive(Kind)
                      ? 0
                      : offsetToAlignment(Size, Align(isBSDLike(Kind) ? 8 : 2));
+
+  Size += Pad;
+  if (Padding)
+    *Padding = Pad;
+  return Size;
+}
+
+static uint64_t computeSymbolMapSize(uint64_t NumObj, SymMap &SymMap,
+                                     uint32_t *Padding = nullptr) {
+  uint64_t Size = sizeof(uint32_t) * 2; // Number of symbols and objects entries
+  Size += NumObj * sizeof(uint32_t);    // Offset table
+
+  for (auto S : SymMap.Map)
+    Size += sizeof(uint16_t) + S.first.length() + 1;
+
+  uint32_t Pad = offsetToAlignment(Size, Align(2));
+  Size += Pad;
+  if (Padding)
+    *Padding = Pad;
+  return Size;
+}
+
+static uint64_t computeECSymbolsSize(SymMap &SymMap,
+                                     uint32_t *Padding = nullptr) {
+  uint64_t Size = sizeof(uint32_t); // Number of symbols
+
+  for (auto S : SymMap.ECMap)
+    Size += sizeof(uint16_t) + S.first.length() + 1;
+
+  uint32_t Pad = offsetToAlignment(Size, Align(2));
   Size += Pad;
   if (Padding)
     *Padding = Pad;
@@ -384,47 +440,161 @@ static uint64_t computeSymbolTableSize(object::Archive::Kind Kind,
 
 static void writeSymbolTableHeader(raw_ostream &Out, object::Archive::Kind Kind,
                                    bool Deterministic, uint64_t Size,
-                                   uint64_t PrevMemberOffset = 0) {
+                                   uint64_t PrevMemberOffset = 0,
+                                   uint64_t NextMemberOffset = 0) {
   if (isBSDLike(Kind)) {
     const char *Name = is64BitKind(Kind) ? "__.SYMDEF_64" : "__.SYMDEF";
     printBSDMemberHeader(Out, Out.tell(), Name, now(Deterministic), 0, 0, 0,
                          Size);
   } else if (isAIXBigArchive(Kind)) {
-    printBigArchiveMemberHeader(Out, "", now(Deterministic), 0, 0,
-                                0, Size, PrevMemberOffset, 0);
+    printBigArchiveMemberHeader(Out, "", now(Deterministic), 0, 0, 0, Size,
+                                PrevMemberOffset, NextMemberOffset);
   } else {
     const char *Name = is64BitKind(Kind) ? "/SYM64" : "";
     printGNUSmallMemberHeader(Out, Name, now(Deterministic), 0, 0, 0, Size);
   }
 }
 
+static uint64_t computeHeadersSize(object::Archive::Kind Kind,
+                                   uint64_t NumMembers,
+                                   uint64_t StringMemberSize, uint64_t NumSyms,
+                                   uint64_t SymNamesSize, SymMap *SymMap) {
+  uint32_t OffsetSize = is64BitKind(Kind) ? 8 : 4;
+  uint64_t SymtabSize =
+      computeSymbolTableSize(Kind, NumSyms, OffsetSize, SymNamesSize);
+  auto computeSymbolTableHeaderSize = [=] {
+    SmallString<0> TmpBuf;
+    raw_svector_ostream Tmp(TmpBuf);
+    writeSymbolTableHeader(Tmp, Kind, true, SymtabSize);
+    return TmpBuf.size();
+  };
+  uint32_t HeaderSize = computeSymbolTableHeaderSize();
+  uint64_t Size = strlen("!<arch>\n") + HeaderSize + SymtabSize;
+
+  if (SymMap) {
+    Size += HeaderSize + computeSymbolMapSize(NumMembers, *SymMap);
+    if (SymMap->ECMap.size())
+      Size += HeaderSize + computeECSymbolsSize(*SymMap);
+  }
+
+  return Size + StringMemberSize;
+}
+
+static Expected<std::unique_ptr<SymbolicFile>>
+getSymbolicFile(MemoryBufferRef Buf, LLVMContext &Context) {
+  const file_magic Type = identify_magic(Buf.getBuffer());
+  // Don't attempt to read non-symbolic file types.
+  if (!object::SymbolicFile::isSymbolicFile(Type, &Context))
+    return nullptr;
+  if (Type == file_magic::bitcode) {
+    auto ObjOrErr = object::SymbolicFile::createSymbolicFile(
+        Buf, file_magic::bitcode, &Context);
+    if (!ObjOrErr)
+      return ObjOrErr.takeError();
+    return std::move(*ObjOrErr);
+  } else {
+    auto ObjOrErr = object::SymbolicFile::createSymbolicFile(Buf);
+    if (!ObjOrErr)
+      return ObjOrErr.takeError();
+    return std::move(*ObjOrErr);
+  }
+}
+
+static bool is64BitSymbolicFile(const SymbolicFile *SymObj) {
+  return SymObj != nullptr ? SymObj->is64Bit() : false;
+}
+
+// Log2 of PAGESIZE(4096) on an AIX system.
+static const uint32_t Log2OfAIXPageSize = 12;
+
+// In the AIX big archive format, since the data content follows the member file
+// name, if the name ends on an odd byte, an extra byte will be added for
+// padding. This ensures that the data within the member file starts at an even
+// byte.
+static const uint32_t MinBigArchiveMemDataAlign = 2;
+
+template <typename AuxiliaryHeader>
+uint16_t getAuxMaxAlignment(uint16_t AuxHeaderSize, AuxiliaryHeader *AuxHeader,
+                            uint16_t Log2OfMaxAlign) {
+  // If the member doesn't have an auxiliary header, it isn't a loadable object
+  // and so it just needs aligning at the minimum value.
+  if (AuxHeader == nullptr)
+    return MinBigArchiveMemDataAlign;
+
+  // If the auxiliary header does not have both MaxAlignOfData and
+  // MaxAlignOfText field, it is not a loadable shared object file, so align at
+  // the minimum value. The 'ModuleType' member is located right after
+  // 'MaxAlignOfData' in the AuxiliaryHeader.
+  if (AuxHeaderSize < offsetof(AuxiliaryHeader, ModuleType))
+    return MinBigArchiveMemDataAlign;
+
+  // If the XCOFF object file does not have a loader section, it is not
+  // loadable, so align at the minimum value.
+  if (AuxHeader->SecNumOfLoader == 0)
+    return MinBigArchiveMemDataAlign;
+
+  // The content of the loadable member file needs to be aligned at MAX(maximum
+  // alignment of .text, maximum alignment of .data) if there are both fields.
+  // If the desired alignment is > PAGESIZE, 32-bit members are aligned on a
+  // word boundary, while 64-bit members are aligned on a PAGESIZE(2^12=4096)
+  // boundary.
+  uint16_t Log2OfAlign =
+      std::max(AuxHeader->MaxAlignOfText, AuxHeader->MaxAlignOfData);
+  return 1 << (Log2OfAlign > Log2OfAIXPageSize ? Log2OfMaxAlign : Log2OfAlign);
+}
+
+// AIX big archives may contain shared object members. The AIX OS requires these
+// members to be aligned if they are 64-bit and recommends it for 32-bit
+// members. This ensures that when these members are loaded they are aligned in
+// memory.
+static uint32_t getMemberAlignment(SymbolicFile *SymObj) {
+  XCOFFObjectFile *XCOFFObj = dyn_cast_or_null<XCOFFObjectFile>(SymObj);
+  if (!XCOFFObj)
+    return MinBigArchiveMemDataAlign;
+
+  // If the desired alignment is > PAGESIZE, 32-bit members are aligned on a
+  // word boundary, while 64-bit members are aligned on a PAGESIZE boundary.
+  return XCOFFObj->is64Bit()
+             ? getAuxMaxAlignment(XCOFFObj->fileHeader64()->AuxHeaderSize,
+                                  XCOFFObj->auxiliaryHeader64(),
+                                  Log2OfAIXPageSize)
+             : getAuxMaxAlignment(XCOFFObj->fileHeader32()->AuxHeaderSize,
+                                  XCOFFObj->auxiliaryHeader32(), 2);
+}
+
 static void writeSymbolTable(raw_ostream &Out, object::Archive::Kind Kind,
                              bool Deterministic, ArrayRef<MemberData> Members,
-                             StringRef StringTable,
-                             uint64_t PrevMemberOffset = 0) {
+                             StringRef StringTable, uint64_t MembersOffset,
+                             unsigned NumSyms, uint64_t PrevMemberOffset = 0,
+                             uint64_t NextMemberOffset = 0,
+                             bool Is64Bit = false) {
   // We don't write a symbol table on an archive with no members -- except on
   // Darwin, where the linker will abort unless the archive has a symbol table.
-  if (StringTable.empty() && !isDarwin(Kind))
+  if (StringTable.empty() && !isDarwin(Kind) && !isCOFFArchive(Kind))
     return;
-
-  unsigned NumSyms = 0;
-  for (const MemberData &M : Members)
-    NumSyms += M.Symbols.size();
 
   uint64_t OffsetSize = is64BitKind(Kind) ? 8 : 4;
   uint32_t Pad;
-  uint64_t Size = computeSymbolTableSize(Kind, NumSyms, OffsetSize, StringTable, &Pad);
-  writeSymbolTableHeader(Out, Kind, Deterministic, Size, PrevMemberOffset);
-
-  uint64_t Pos = isAIXBigArchive(Kind) ? sizeof(object::BigArchive::FixLenHdr)
-                                       : Out.tell() + Size;
+  uint64_t Size = computeSymbolTableSize(Kind, NumSyms, OffsetSize,
+                                         StringTable.size(), &Pad);
+  writeSymbolTableHeader(Out, Kind, Deterministic, Size, PrevMemberOffset,
+                         NextMemberOffset);
 
   if (isBSDLike(Kind))
     printNBits(Out, Kind, NumSyms * 2 * OffsetSize);
   else
     printNBits(Out, Kind, NumSyms);
 
+  uint64_t Pos = MembersOffset;
   for (const MemberData &M : Members) {
+    if (isAIXBigArchive(Kind)) {
+      Pos += M.PreHeadPadSize;
+      if (is64BitSymbolicFile(M.SymFile.get()) != Is64Bit) {
+        Pos += M.Header.size() + M.Data.size() + M.Padding.size();
+        continue;
+      }
+    }
+
     for (unsigned StringOffset : M.Symbols) {
       if (isBSDLike(Kind))
         printNBits(Out, Kind, StringOffset);
@@ -442,40 +612,116 @@ static void writeSymbolTable(raw_ostream &Out, object::Archive::Kind Kind,
     Out.write(uint8_t(0));
 }
 
-static Expected<std::vector<unsigned>>
-getSymbols(MemoryBufferRef Buf, raw_ostream &SymNames, bool &HasObject) {
-  std::vector<unsigned> Ret;
+static void writeSymbolMap(raw_ostream &Out, object::Archive::Kind Kind,
+                           bool Deterministic, ArrayRef<MemberData> Members,
+                           SymMap &SymMap, uint64_t MembersOffset) {
+  uint32_t Pad;
+  uint64_t Size = computeSymbolMapSize(Members.size(), SymMap, &Pad);
+  writeSymbolTableHeader(Out, Kind, Deterministic, Size, 0);
 
-  // In the scenario when LLVMContext is populated SymbolicFile will contain a
-  // reference to it, thus SymbolicFile should be destroyed first.
-  LLVMContext Context;
-  std::unique_ptr<object::SymbolicFile> Obj;
+  uint32_t Pos = MembersOffset;
 
-  const file_magic Type = identify_magic(Buf.getBuffer());
-  // Treat unsupported file types as having no symbols.
-  if (!object::SymbolicFile::isSymbolicFile(Type, &Context))
-    return Ret;
-  if (Type == file_magic::bitcode) {
-    auto ObjOrErr = object::SymbolicFile::createSymbolicFile(
-        Buf, file_magic::bitcode, &Context);
-    if (!ObjOrErr)
-      return ObjOrErr.takeError();
-    Obj = std::move(*ObjOrErr);
-  } else {
-    auto ObjOrErr = object::SymbolicFile::createSymbolicFile(Buf);
-    if (!ObjOrErr)
-      return ObjOrErr.takeError();
-    Obj = std::move(*ObjOrErr);
+  printLE<uint32_t>(Out, Members.size());
+  for (const MemberData &M : Members) {
+    printLE(Out, Pos); // member offset
+    Pos += M.Header.size() + M.Data.size() + M.Padding.size();
   }
 
-  HasObject = true;
+  printLE<uint32_t>(Out, SymMap.Map.size());
+
+  for (auto S : SymMap.Map)
+    printLE(Out, S.second);
+  for (auto S : SymMap.Map)
+    Out << S.first << '\0';
+
+  while (Pad--)
+    Out.write(uint8_t(0));
+}
+
+static void writeECSymbols(raw_ostream &Out, object::Archive::Kind Kind,
+                           bool Deterministic, ArrayRef<MemberData> Members,
+                           SymMap &SymMap) {
+  uint32_t Pad;
+  uint64_t Size = computeECSymbolsSize(SymMap, &Pad);
+  printGNUSmallMemberHeader(Out, "/<ECSYMBOLS>", now(Deterministic), 0, 0, 0,
+                            Size);
+
+  printLE<uint32_t>(Out, SymMap.ECMap.size());
+
+  for (auto S : SymMap.ECMap)
+    printLE(Out, S.second);
+  for (auto S : SymMap.ECMap)
+    Out << S.first << '\0';
+  while (Pad--)
+    Out.write(uint8_t(0));
+}
+
+static bool isECObject(object::SymbolicFile &Obj) {
+  if (Obj.isCOFF())
+    return cast<llvm::object::COFFObjectFile>(&Obj)->getMachine() !=
+           COFF::IMAGE_FILE_MACHINE_ARM64;
+
+  if (Obj.isCOFFImportFile())
+    return cast<llvm::object::COFFImportFile>(&Obj)->getMachine() !=
+           COFF::IMAGE_FILE_MACHINE_ARM64;
+
+  if (Obj.isIR()) {
+    Expected<std::string> TripleStr =
+        getBitcodeTargetTriple(Obj.getMemoryBufferRef());
+    if (!TripleStr)
+      return false;
+    Triple T(*TripleStr);
+    return T.isWindowsArm64EC() || T.getArch() == Triple::x86_64;
+  }
+
+  return false;
+}
+
+bool isImportDescriptor(StringRef Name) {
+  return Name.starts_with(ImportDescriptorPrefix) ||
+         Name == StringRef{NullImportDescriptorSymbolName} ||
+         (Name.starts_with(NullThunkDataPrefix) &&
+          Name.ends_with(NullThunkDataSuffix));
+}
+
+static Expected<std::vector<unsigned>> getSymbols(SymbolicFile *Obj,
+                                                  uint16_t Index,
+                                                  raw_ostream &SymNames,
+                                                  SymMap *SymMap) {
+  std::vector<unsigned> Ret;
+
+  if (Obj == nullptr)
+    return Ret;
+
+  std::map<std::string, uint16_t> *Map = nullptr;
+  if (SymMap)
+    Map = SymMap->UseECMap && isECObject(*Obj) ? &SymMap->ECMap : &SymMap->Map;
+
   for (const object::BasicSymbolRef &S : Obj->symbols()) {
     if (!isArchiveSymbol(S))
       continue;
-    Ret.push_back(SymNames.tell());
-    if (Error E = S.printName(SymNames))
-      return std::move(E);
-    SymNames << '\0';
+    if (Map) {
+      std::string Name;
+      raw_string_ostream NameStream(Name);
+      if (Error E = S.printName(NameStream))
+        return std::move(E);
+      if (Map->find(Name) != Map->end())
+        continue; // ignore duplicated symbol
+      (*Map)[Name] = Index;
+      if (Map == &SymMap->Map) {
+        Ret.push_back(SymNames.tell());
+        SymNames << Name << '\0';
+        // If EC is enabled, then the import descriptors are NOT put into EC
+        // objects so we need to copy them to the EC map manually.
+        if (SymMap->UseECMap && isImportDescriptor(Name))
+          SymMap->ECMap[Name] = Index;
+      }
+    } else {
+      Ret.push_back(SymNames.tell());
+      if (Error E = S.printName(SymNames))
+        return std::move(E);
+      SymNames << '\0';
+    }
   }
   return Ret;
 }
@@ -483,9 +729,10 @@ getSymbols(MemoryBufferRef Buf, raw_ostream &SymNames, bool &HasObject) {
 static Expected<std::vector<MemberData>>
 computeMemberData(raw_ostream &StringTable, raw_ostream &SymNames,
                   object::Archive::Kind Kind, bool Thin, bool Deterministic,
-                  bool NeedSymbols, ArrayRef<NewArchiveMember> NewMembers) {
+                  SymtabWritingMode NeedSymbols, SymMap *SymMap,
+                  LLVMContext &Context, ArrayRef<NewArchiveMember> NewMembers) {
   static char PaddingData[8] = {'\n', '\n', '\n', '\n', '\n', '\n', '\n', '\n'};
-
+  uint64_t MemHeadPadSize = 0;
   uint64_t Pos =
       isAIXBigArchive(Kind) ? sizeof(object::BigArchive::FixLenHdr) : 0;
 
@@ -500,7 +747,7 @@ computeMemberData(raw_ostream &StringTable, raw_ostream &SymNames,
   // UniqueTimestamps is a special case to improve debugging on Darwin:
   //
   // The Darwin linker does not link debug info into the final
-  // binary. Instead, it emits entries of type N_OSO in in the output
+  // binary. Instead, it emits entries of type N_OSO in the output
   // binary's symbol table, containing references to the linked-in
   // object files. Using that reference, the debugger can read the
   // debug data directly from the object files. Alternatively, an
@@ -549,13 +796,20 @@ computeMemberData(raw_ostream &StringTable, raw_ostream &SymNames,
 
   // The big archive format needs to know the offset of the previous member
   // header.
-  unsigned PrevOffset = 0;
-  for (const NewArchiveMember &M : NewMembers) {
+  uint64_t PrevOffset = 0;
+  uint64_t NextMemHeadPadSize = 0;
+  std::unique_ptr<SymbolicFile> CurSymFile;
+  std::unique_ptr<SymbolicFile> NextSymFile;
+  uint16_t Index = 0;
+
+  for (auto M = NewMembers.begin(); M < NewMembers.end(); ++M) {
     std::string Header;
     raw_string_ostream Out(Header);
 
-    MemoryBufferRef Buf = M.Buf->getMemBufferRef();
+    MemoryBufferRef Buf = M->Buf->getMemBufferRef();
     StringRef Data = Thin ? "" : Buf.getBuffer();
+
+    Index++;
 
     // ld64 expects the members to be 8-byte aligned for 64-bit content and at
     // least 4-byte aligned for 32-bit content.  Opt for the larger encoding
@@ -570,48 +824,101 @@ computeMemberData(raw_ostream &StringTable, raw_ostream &SymNames,
     sys::TimePoint<std::chrono::seconds> ModTime;
     if (UniqueTimestamps)
       // Increment timestamp for each file of a given name.
-      ModTime = sys::toTimePoint(FilenameCount[M.MemberName]++);
+      ModTime = sys::toTimePoint(FilenameCount[M->MemberName]++);
     else
-      ModTime = M.ModTime;
+      ModTime = M->ModTime;
 
     uint64_t Size = Buf.getBufferSize() + MemberPadding;
     if (Size > object::Archive::MaxMemberSize) {
       std::string StringMsg =
-          "File " + M.MemberName.str() + " exceeds size limit";
+          "File " + M->MemberName.str() + " exceeds size limit";
       return make_error<object::GenericBinaryError>(
           std::move(StringMsg), object::object_error::parse_failed);
     }
 
+    if (NeedSymbols != SymtabWritingMode::NoSymtab || isAIXBigArchive(Kind)) {
+      auto SetNextSymFile = [&NextSymFile,
+                             &Context](MemoryBufferRef Buf,
+                                       StringRef MemberName) -> Error {
+        Expected<std::unique_ptr<SymbolicFile>> SymFileOrErr =
+            getSymbolicFile(Buf, Context);
+        if (!SymFileOrErr)
+          return createFileError(MemberName, SymFileOrErr.takeError());
+        NextSymFile = std::move(*SymFileOrErr);
+        return Error::success();
+      };
+
+      if (M == NewMembers.begin())
+        if (Error Err = SetNextSymFile(Buf, M->MemberName))
+          return std::move(Err);
+
+      CurSymFile = std::move(NextSymFile);
+
+      if ((M + 1) != NewMembers.end())
+        if (Error Err = SetNextSymFile((M + 1)->Buf->getMemBufferRef(),
+                                       (M + 1)->MemberName))
+          return std::move(Err);
+    }
+
+    // In the big archive file format, we need to calculate and include the next
+    // member offset and previous member offset in the file member header.
     if (isAIXBigArchive(Kind)) {
-      unsigned NextOffset = Pos + sizeof(object::BigArMemHdrType) +
-                            alignTo(M.MemberName.size(), 2) + alignTo(Size, 2);
-      printBigArchiveMemberHeader(Out, M.MemberName, ModTime, M.UID, M.GID,
-                                  M.Perms, Size, PrevOffset, NextOffset);
+      uint64_t OffsetToMemData = Pos + sizeof(object::BigArMemHdrType) +
+                                 alignTo(M->MemberName.size(), 2);
+
+      if (M == NewMembers.begin())
+        NextMemHeadPadSize =
+            alignToPowerOf2(OffsetToMemData,
+                            getMemberAlignment(CurSymFile.get())) -
+            OffsetToMemData;
+
+      MemHeadPadSize = NextMemHeadPadSize;
+      Pos += MemHeadPadSize;
+      uint64_t NextOffset = Pos + sizeof(object::BigArMemHdrType) +
+                            alignTo(M->MemberName.size(), 2) + alignTo(Size, 2);
+
+      // If there is another member file after this, we need to calculate the
+      // padding before the header.
+      if ((M + 1) != NewMembers.end()) {
+        uint64_t OffsetToNextMemData = NextOffset +
+                                       sizeof(object::BigArMemHdrType) +
+                                       alignTo((M + 1)->MemberName.size(), 2);
+        NextMemHeadPadSize =
+            alignToPowerOf2(OffsetToNextMemData,
+                            getMemberAlignment(NextSymFile.get())) -
+            OffsetToNextMemData;
+        NextOffset += NextMemHeadPadSize;
+      }
+      printBigArchiveMemberHeader(Out, M->MemberName, ModTime, M->UID, M->GID,
+                                  M->Perms, Size, PrevOffset, NextOffset);
       PrevOffset = Pos;
     } else {
-      printMemberHeader(Out, Pos, StringTable, MemberNames, Kind, Thin, M,
+      printMemberHeader(Out, Pos, StringTable, MemberNames, Kind, Thin, *M,
                         ModTime, Size);
     }
     Out.flush();
 
     std::vector<unsigned> Symbols;
-    if (NeedSymbols) {
+    if (NeedSymbols != SymtabWritingMode::NoSymtab) {
       Expected<std::vector<unsigned>> SymbolsOrErr =
-          getSymbols(Buf, SymNames, HasObject);
-      if (auto E = SymbolsOrErr.takeError())
-        return std::move(E);
+          getSymbols(CurSymFile.get(), Index, SymNames, SymMap);
+      if (!SymbolsOrErr)
+        return createFileError(M->MemberName, SymbolsOrErr.takeError());
       Symbols = std::move(*SymbolsOrErr);
+      if (CurSymFile)
+        HasObject = true;
     }
 
     Pos += Header.size() + Data.size() + Padding.size();
-    Ret.push_back({std::move(Symbols), std::move(Header), Data, Padding});
+    Ret.push_back({std::move(Symbols), std::move(Header), Data, Padding,
+                   MemHeadPadSize, std::move(CurSymFile)});
   }
   // If there are no symbols, emit an empty symbol table, to satisfy Solaris
   // tools, older versions of which expect a symbol table in a non-empty
   // archive, regardless of whether there are any symbols in it.
-  if (HasObject && SymNames.tell() == 0)
+  if (HasObject && SymNames.tell() == 0 && !isCOFFArchive(Kind))
     SymNames << '\0' << '\0' << '\0';
-  return Ret;
+  return std::move(Ret);
 }
 
 namespace llvm {
@@ -654,56 +961,83 @@ Expected<std::string> computeArchiveRelativePath(StringRef From, StringRef To) {
   for (auto ToE = sys::path::end(PathTo); ToI != ToE; ++ToI)
     sys::path::append(Relative, sys::path::Style::posix, *ToI);
 
-  return std::string(Relative.str());
+  return std::string(Relative);
 }
 
 static Error writeArchiveToStream(raw_ostream &Out,
                                   ArrayRef<NewArchiveMember> NewMembers,
-                                  bool WriteSymtab, object::Archive::Kind Kind,
-                                  bool Deterministic, bool Thin) {
+                                  SymtabWritingMode WriteSymtab,
+                                  object::Archive::Kind Kind,
+                                  bool Deterministic, bool Thin, bool IsEC) {
   assert((!Thin || !isBSDLike(Kind)) && "Only the gnu format has a thin mode");
 
   SmallString<0> SymNamesBuf;
   raw_svector_ostream SymNames(SymNamesBuf);
   SmallString<0> StringTableBuf;
   raw_svector_ostream StringTable(StringTableBuf);
+  SymMap SymMap;
 
-  Expected<std::vector<MemberData>> DataOrErr =
-      computeMemberData(StringTable, SymNames, Kind, Thin, Deterministic,
-                        WriteSymtab, NewMembers);
+  // COFF symbol map uses 16-bit indexes, so we can't use it if there are too
+  // many members.
+  if (isCOFFArchive(Kind) && NewMembers.size() > 0xfffe)
+    Kind = object::Archive::K_GNU;
+
+  // In the scenario when LLVMContext is populated SymbolicFile will contain a
+  // reference to it, thus SymbolicFile should be destroyed first.
+  LLVMContext Context;
+
+  SymMap.UseECMap = IsEC;
+  Expected<std::vector<MemberData>> DataOrErr = computeMemberData(
+      StringTable, SymNames, Kind, Thin, Deterministic, WriteSymtab,
+      isCOFFArchive(Kind) ? &SymMap : nullptr, Context, NewMembers);
   if (Error E = DataOrErr.takeError())
     return E;
   std::vector<MemberData> &Data = *DataOrErr;
 
-  if (!StringTableBuf.empty() && !isAIXBigArchive(Kind))
-    Data.insert(Data.begin(), computeStringTable(StringTableBuf));
+  uint64_t StringTableSize = 0;
+  MemberData StringTableMember;
+  if (!StringTableBuf.empty() && !isAIXBigArchive(Kind)) {
+    StringTableMember = computeStringTable(StringTableBuf);
+    StringTableSize = StringTableMember.Header.size() +
+                      StringTableMember.Data.size() +
+                      StringTableMember.Padding.size();
+  }
 
   // We would like to detect if we need to switch to a 64-bit symbol table.
-  uint64_t LastMemberEndOffset =
-      isAIXBigArchive(Kind) ? sizeof(object::BigArchive::FixLenHdr) : 8;
-  uint64_t LastMemberHeaderOffset = LastMemberEndOffset;
+  uint64_t LastMemberEndOffset = 0;
+  uint64_t LastMemberHeaderOffset = 0;
   uint64_t NumSyms = 0;
+  uint64_t NumSyms32 = 0; // Store symbol number of 32-bit member files.
+  bool ShouldWriteSymtab = WriteSymtab != SymtabWritingMode::NoSymtab;
+
   for (const auto &M : Data) {
     // Record the start of the member's offset
+    LastMemberEndOffset += M.PreHeadPadSize;
     LastMemberHeaderOffset = LastMemberEndOffset;
     // Account for the size of each part associated with the member.
     LastMemberEndOffset += M.Header.size() + M.Data.size() + M.Padding.size();
     NumSyms += M.Symbols.size();
+
+    // AIX big archive files may contain two global symbol tables. The
+    // first global symbol table locates 32-bit file members that define global
+    // symbols; the second global symbol table does the same for 64-bit file
+    // members. As a big archive can have both 32-bit and 64-bit file members,
+    // we need to know the number of symbols in each symbol table individually.
+    if (isAIXBigArchive(Kind) && ShouldWriteSymtab) {
+        if (!is64BitSymbolicFile(M.SymFile.get()))
+          NumSyms32 += M.Symbols.size();
+      }
   }
+
+  std::optional<uint64_t> HeadersSize;
 
   // The symbol table is put at the end of the big archive file. The symbol
   // table is at the start of the archive file for other archive formats.
-  if (WriteSymtab && !isAIXBigArchive(Kind)) {
+  if (ShouldWriteSymtab && !is64BitKind(Kind)) {
     // We assume 32-bit offsets to see if 32-bit symbols are possible or not.
-    uint64_t SymtabSize = computeSymbolTableSize(Kind, NumSyms, 4, SymNamesBuf);
-    auto computeSymbolTableHeaderSize =
-        [=] {
-          SmallString<0> TmpBuf;
-          raw_svector_ostream Tmp(TmpBuf);
-          writeSymbolTableHeader(Tmp, Kind, Deterministic, SymtabSize);
-          return TmpBuf.size();
-        };
-    LastMemberHeaderOffset += computeSymbolTableHeaderSize() + SymtabSize;
+    HeadersSize = computeHeadersSize(Kind, Data.size(), StringTableSize,
+                                     NumSyms, SymNamesBuf.size(),
+                                     isCOFFArchive(Kind) ? &SymMap : nullptr);
 
     // The SYM64 format is used when an archive's member offsets are larger than
     // 32-bits can hold. The need for this shift in format is detected by
@@ -720,11 +1054,12 @@ static Error writeArchiveToStream(raw_ostream &Out,
     // If LastMemberHeaderOffset isn't going to fit in a 32-bit varible we need
     // to switch to 64-bit. Note that the file can be larger than 4GB as long as
     // the last member starts before the 4GB offset.
-    if (LastMemberHeaderOffset >= Sym64Threshold) {
+    if (*HeadersSize + LastMemberHeaderOffset >= Sym64Threshold) {
       if (Kind == object::Archive::K_DARWIN)
         Kind = object::Archive::K_DARWIN64;
       else
         Kind = object::Archive::K_GNU64;
+      HeadersSize.reset();
     }
   }
 
@@ -736,11 +1071,32 @@ static Error writeArchiveToStream(raw_ostream &Out,
     Out << "!<arch>\n";
 
   if (!isAIXBigArchive(Kind)) {
-    if (WriteSymtab)
-      writeSymbolTable(Out, Kind, Deterministic, Data, SymNamesBuf);
+    if (ShouldWriteSymtab) {
+      if (!HeadersSize)
+        HeadersSize = computeHeadersSize(
+            Kind, Data.size(), StringTableSize, NumSyms, SymNamesBuf.size(),
+            isCOFFArchive(Kind) ? &SymMap : nullptr);
+      writeSymbolTable(Out, Kind, Deterministic, Data, SymNamesBuf,
+                       *HeadersSize, NumSyms);
+
+      if (isCOFFArchive(Kind))
+        writeSymbolMap(Out, Kind, Deterministic, Data, SymMap, *HeadersSize);
+    }
+
+    if (StringTableSize)
+      Out << StringTableMember.Header << StringTableMember.Data
+          << StringTableMember.Padding;
+
+    if (ShouldWriteSymtab && SymMap.ECMap.size())
+      writeECSymbols(Out, Kind, Deterministic, Data, SymMap);
+
     for (const MemberData &M : Data)
       Out << M.Header << M.Data << M.Padding;
   } else {
+    HeadersSize = sizeof(object::BigArchive::FixLenHdr);
+    LastMemberEndOffset += *HeadersSize;
+    LastMemberHeaderOffset += *HeadersSize;
+
     // For the big archive (AIX) format, compute a table of member names and
     // offsets, used in the member table.
     uint64_t MemberTableNameStrTblSize = 0;
@@ -751,38 +1107,77 @@ static Error writeArchiveToStream(raw_ostream &Out,
     for (size_t I = 0, Size = NewMembers.size(); I != Size; ++I) {
       const NewArchiveMember &Member = NewMembers[I];
       MemberTableNameStrTblSize += Member.MemberName.size() + 1;
+      MemberEndOffset += Data[I].PreHeadPadSize;
       MemberOffsets.push_back(MemberEndOffset);
       MemberNames.push_back(Member.MemberName);
       // File member name ended with "`\n". The length is included in
       // BigArMemHdrType.
       MemberEndOffset += sizeof(object::BigArMemHdrType) +
-                             alignTo(Data[I].Data.size(), 2) +
-                             alignTo(Member.MemberName.size(), 2);
+                         alignTo(Data[I].Data.size(), 2) +
+                         alignTo(Member.MemberName.size(), 2);
     }
 
     // AIX member table size.
-    unsigned MemberTableSize = 20 + // Number of members field
+    uint64_t MemberTableSize = 20 + // Number of members field
                                20 * MemberOffsets.size() +
                                MemberTableNameStrTblSize;
 
-    unsigned GlobalSymbolOffset =
-        (WriteSymtab && NumSyms > 0)
-            ? LastMemberEndOffset +
-                  alignTo(sizeof(object::BigArMemHdrType) + MemberTableSize, 2)
+    SmallString<0> SymNamesBuf32;
+    SmallString<0> SymNamesBuf64;
+    raw_svector_ostream SymNames32(SymNamesBuf32);
+    raw_svector_ostream SymNames64(SymNamesBuf64);
+
+    if (ShouldWriteSymtab && NumSyms)
+      // Generate the symbol names for the members.
+      for (const auto &M : Data) {
+        Expected<std::vector<unsigned>> SymbolsOrErr = getSymbols(
+            M.SymFile.get(), 0,
+            is64BitSymbolicFile(M.SymFile.get()) ? SymNames64 : SymNames32,
+            nullptr);
+        if (!SymbolsOrErr)
+          return SymbolsOrErr.takeError();
+      }
+
+    uint64_t MemberTableEndOffset =
+        LastMemberEndOffset +
+        alignTo(sizeof(object::BigArMemHdrType) + MemberTableSize, 2);
+
+    // In AIX OS, The 'GlobSymOffset' field in the fixed-length header contains
+    // the offset to the 32-bit global symbol table, and the 'GlobSym64Offset'
+    // contains the offset to the 64-bit global symbol table.
+    uint64_t GlobalSymbolOffset =
+        (ShouldWriteSymtab &&
+         (WriteSymtab != SymtabWritingMode::BigArchive64) && NumSyms32 > 0)
+            ? MemberTableEndOffset
             : 0;
+
+    uint64_t GlobalSymbolOffset64 = 0;
+    uint64_t NumSyms64 = NumSyms - NumSyms32;
+    if (ShouldWriteSymtab && (WriteSymtab != SymtabWritingMode::BigArchive32) &&
+        NumSyms64 > 0) {
+      if (GlobalSymbolOffset == 0)
+        GlobalSymbolOffset64 = MemberTableEndOffset;
+      else
+        // If there is a global symbol table for 32-bit members,
+        // the 64-bit global symbol table is after the 32-bit one.
+        GlobalSymbolOffset64 =
+            GlobalSymbolOffset + sizeof(object::BigArMemHdrType) +
+            (NumSyms32 + 1) * 8 + alignTo(SymNamesBuf32.size(), 2);
+    }
 
     // Fixed Sized Header.
     printWithSpacePadding(Out, NewMembers.size() ? LastMemberEndOffset : 0,
                           20); // Offset to member table
     // If there are no file members in the archive, there will be no global
     // symbol table.
-    printWithSpacePadding(Out, NewMembers.size() ? GlobalSymbolOffset : 0, 20);
-    printWithSpacePadding(
-        Out, 0,
-        20); // Offset to 64 bits global symbol table - Not supported yet
-    printWithSpacePadding(
-        Out, NewMembers.size() ? sizeof(object::BigArchive::FixLenHdr) : 0,
-        20); // Offset to first archive member
+    printWithSpacePadding(Out, GlobalSymbolOffset, 20);
+    printWithSpacePadding(Out, GlobalSymbolOffset64, 20);
+    printWithSpacePadding(Out,
+                          NewMembers.size()
+                              ? sizeof(object::BigArchive::FixLenHdr) +
+                                    Data[0].PreHeadPadSize
+                              : 0,
+                          20); // Offset to first archive member
     printWithSpacePadding(Out, NewMembers.size() ? LastMemberHeaderOffset : 0,
                           20); // Offset to last archive member
     printWithSpacePadding(
@@ -790,6 +1185,7 @@ static Error writeArchiveToStream(raw_ostream &Out,
         20); // Offset to first member of free list - Not supported yet
 
     for (const MemberData &M : Data) {
+      Out << std::string(M.PreHeadPadSize, '\0');
       Out << M.Header << M.Data;
       if (M.Data.size() % 2)
         Out << '\0';
@@ -799,7 +1195,8 @@ static Error writeArchiveToStream(raw_ostream &Out,
       // Member table.
       printBigArchiveMemberHeader(Out, "", sys::toTimePoint(0), 0, 0, 0,
                                   MemberTableSize, LastMemberHeaderOffset,
-                                  GlobalSymbolOffset);
+                                  GlobalSymbolOffset ? GlobalSymbolOffset
+                                                     : GlobalSymbolOffset64);
       printWithSpacePadding(Out, MemberOffsets.size(), 20); // Number of members
       for (uint64_t MemberOffset : MemberOffsets)
         printWithSpacePadding(Out, MemberOffset,
@@ -811,9 +1208,25 @@ static Error writeArchiveToStream(raw_ostream &Out,
         Out << '\0'; // Name table must be tail padded to an even number of
                      // bytes.
 
-      if (WriteSymtab && NumSyms > 0)
-        writeSymbolTable(Out, Kind, Deterministic, Data, SymNamesBuf,
-                         LastMemberEndOffset);
+      if (ShouldWriteSymtab) {
+        // Write global symbol table for 32-bit file members.
+        if (GlobalSymbolOffset) {
+          writeSymbolTable(Out, Kind, Deterministic, Data, SymNamesBuf32,
+                           *HeadersSize, NumSyms32, LastMemberEndOffset,
+                           GlobalSymbolOffset64);
+          // Add padding between the symbol tables, if needed.
+          if (GlobalSymbolOffset64 && (SymNamesBuf32.size() % 2))
+            Out << '\0';
+        }
+
+        // Write global symbol table for 64-bit file members.
+        if (GlobalSymbolOffset64)
+          writeSymbolTable(Out, Kind, Deterministic, Data, SymNamesBuf64,
+                           *HeadersSize, NumSyms64,
+                           GlobalSymbolOffset ? GlobalSymbolOffset
+                                              : LastMemberEndOffset,
+                           0, true);
+      }
     }
   }
   Out.flush();
@@ -821,9 +1234,9 @@ static Error writeArchiveToStream(raw_ostream &Out,
 }
 
 Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
-                   bool WriteSymtab, object::Archive::Kind Kind,
+                   SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
                    bool Deterministic, bool Thin,
-                   std::unique_ptr<MemoryBuffer> OldArchiveBuf) {
+                   std::unique_ptr<MemoryBuffer> OldArchiveBuf, bool IsEC) {
   Expected<sys::fs::TempFile> Temp =
       sys::fs::TempFile::create(ArcName + ".temp-archive-%%%%%%%.a");
   if (!Temp)
@@ -831,7 +1244,7 @@ Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
   raw_fd_ostream Out(Temp->FD, false);
 
   if (Error E = writeArchiveToStream(Out, NewMembers, WriteSymtab, Kind,
-                                     Deterministic, Thin)) {
+                                     Deterministic, Thin, IsEC)) {
     if (Error DiscardError = Temp->discard())
       return joinErrors(std::move(E), std::move(DiscardError));
     return E;
@@ -853,14 +1266,14 @@ Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
 }
 
 Expected<std::unique_ptr<MemoryBuffer>>
-writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers, bool WriteSymtab,
-                     object::Archive::Kind Kind, bool Deterministic,
-                     bool Thin) {
+writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers,
+                     SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
+                     bool Deterministic, bool Thin) {
   SmallVector<char, 0> ArchiveBufferVector;
   raw_svector_ostream ArchiveStream(ArchiveBufferVector);
 
   if (Error E = writeArchiveToStream(ArchiveStream, NewMembers, WriteSymtab,
-                                     Kind, Deterministic, Thin))
+                                     Kind, Deterministic, Thin, false))
     return std::move(E);
 
   return std::make_unique<SmallVectorMemoryBuffer>(

--- a/reference/ArchiveWriter.cpp
+++ b/reference/ArchiveWriter.cpp
@@ -1,5 +1,3 @@
-// Copied from https://github.com/llvm/llvm-project/blob/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2/llvm/lib/Object/ArchiveWriter.cpp
-
 //===- ArchiveWriter.cpp - ar File Format implementation --------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/reference/ArchiveWriter.h
+++ b/reference/ArchiveWriter.h
@@ -40,16 +40,26 @@ struct NewArchiveMember {
 
 Expected<std::string> computeArchiveRelativePath(StringRef From, StringRef To);
 
+enum class SymtabWritingMode {
+  NoSymtab,     // Do not write symbol table.
+  NormalSymtab, // Write symbol table. For the Big Archive format, write both
+                // 32-bit and 64-bit symbol tables.
+  BigArchive32, // Only write the 32-bit symbol table.
+  BigArchive64  // Only write the 64-bit symbol table.
+};
+
 Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
-                   bool WriteSymtab, object::Archive::Kind Kind,
+                   SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
                    bool Deterministic, bool Thin,
-                   std::unique_ptr<MemoryBuffer> OldArchiveBuf = nullptr);
+                   std::unique_ptr<MemoryBuffer> OldArchiveBuf = nullptr,
+                   bool IsEC = false);
 
 // writeArchiveToBuffer is similar to writeArchive but returns the Archive in a
 // buffer instead of writing it out to a file.
 Expected<std::unique_ptr<MemoryBuffer>>
-writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers, bool WriteSymtab,
-                     object::Archive::Kind Kind, bool Deterministic, bool Thin);
+writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers,
+                     SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
+                     bool Deterministic, bool Thin);
 }
 
 #endif

--- a/reference/ArchiveWriter.h
+++ b/reference/ArchiveWriter.h
@@ -1,5 +1,3 @@
-// Copied from https://github.com/llvm/llvm-project/blob/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2/llvm/include/llvm/Object/ArchiveWriter.h
-
 //===- ArchiveWriter.h - ar archive file format writer ----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/reference/COFFImportFile.h
+++ b/reference/COFFImportFile.h
@@ -1,0 +1,144 @@
+//===- COFFImportFile.h - COFF short import file implementation -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// COFF short import file is a special kind of file which contains
+// only symbol names for DLL-exported symbols. This class implements
+// exporting of Symbols to create libraries and a SymbolicFile
+// interface for the file type.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_OBJECT_COFFIMPORTFILE_H
+#define LLVM_OBJECT_COFFIMPORTFILE_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/Mangler.h"
+#include "llvm/Object/COFF.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Object/SymbolicFile.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace llvm {
+namespace object {
+
+constexpr std::string_view ImportDescriptorPrefix = "__IMPORT_DESCRIPTOR_";
+constexpr std::string_view NullImportDescriptorSymbolName =
+    "__NULL_IMPORT_DESCRIPTOR";
+constexpr std::string_view NullThunkDataPrefix = "\x7f";
+constexpr std::string_view NullThunkDataSuffix = "_NULL_THUNK_DATA";
+
+class COFFImportFile : public SymbolicFile {
+private:
+  enum SymbolIndex { ImpSymbol, ThunkSymbol, ECAuxSymbol, ECThunkSymbol };
+
+public:
+  COFFImportFile(MemoryBufferRef Source)
+      : SymbolicFile(ID_COFFImportFile, Source) {}
+
+  static bool classof(Binary const *V) { return V->isCOFFImportFile(); }
+
+  void moveSymbolNext(DataRefImpl &Symb) const override { ++Symb.p; }
+
+  Error printSymbolName(raw_ostream &OS, DataRefImpl Symb) const override;
+
+  Expected<uint32_t> getSymbolFlags(DataRefImpl Symb) const override {
+    return SymbolRef::SF_Global;
+  }
+
+  basic_symbol_iterator symbol_begin() const override {
+    return BasicSymbolRef(DataRefImpl(), this);
+  }
+
+  basic_symbol_iterator symbol_end() const override {
+    DataRefImpl Symb;
+    if (isData())
+      Symb.p = ImpSymbol + 1;
+    else if (COFF::isArm64EC(getMachine()))
+      Symb.p = ECThunkSymbol + 1;
+    else
+      Symb.p = ThunkSymbol + 1;
+    return BasicSymbolRef(Symb, this);
+  }
+
+  bool is64Bit() const override { return false; }
+
+  const coff_import_header *getCOFFImportHeader() const {
+    return reinterpret_cast<const object::coff_import_header *>(
+        Data.getBufferStart());
+  }
+
+  uint16_t getMachine() const { return getCOFFImportHeader()->Machine; }
+
+  StringRef getFileFormatName() const;
+  StringRef getExportName() const;
+
+private:
+  bool isData() const {
+    return getCOFFImportHeader()->getType() == COFF::IMPORT_DATA;
+  }
+};
+
+struct COFFShortExport {
+  /// The name of the export as specified in the .def file or on the command
+  /// line, i.e. "foo" in "/EXPORT:foo", and "bar" in "/EXPORT:foo=bar". This
+  /// may lack mangling, such as underscore prefixing and stdcall suffixing.
+  std::string Name;
+
+  /// The external, exported name. Only non-empty when export renaming is in
+  /// effect, i.e. "foo" in "/EXPORT:foo=bar".
+  std::string ExtName;
+
+  /// The real, mangled symbol name from the object file. Given
+  /// "/export:foo=bar", this could be "_bar@8" if bar is stdcall.
+  std::string SymbolName;
+
+  /// Creates a weak alias. This is the name of the weak aliasee. In a .def
+  /// file, this is "baz" in "EXPORTS\nfoo = bar == baz".
+  std::string AliasTarget;
+
+  /// Specifies EXPORTAS name. In a .def file, this is "bar" in
+  /// "EXPORTS\nfoo EXPORTAS bar".
+  std::string ExportAs;
+
+  uint16_t Ordinal = 0;
+  bool Noname = false;
+  bool Data = false;
+  bool Private = false;
+  bool Constant = false;
+
+  friend bool operator==(const COFFShortExport &L, const COFFShortExport &R) {
+    return L.Name == R.Name && L.ExtName == R.ExtName &&
+            L.Ordinal == R.Ordinal && L.Noname == R.Noname &&
+            L.Data == R.Data && L.Private == R.Private;
+  }
+
+  friend bool operator!=(const COFFShortExport &L, const COFFShortExport &R) {
+    return !(L == R);
+  }
+};
+
+/// Writes a COFF import library containing entries described by the Exports
+/// array.
+///
+/// For hybrid targets such as ARM64EC, additional native entry points can be
+/// exposed using the NativeExports parameter. When NativeExports is used, the
+/// output import library will expose these native ARM64 imports alongside the
+/// entries described in the Exports array. Such a library can be used for
+/// linking both ARM64EC and pure ARM64 objects, and the linker will pick only
+/// the exports relevant to the target platform. For non-hybrid targets,
+/// the NativeExports parameter should not be used.
+Error writeImportLibrary(
+    StringRef ImportName, StringRef Path, ArrayRef<COFFShortExport> Exports,
+    COFF::MachineTypes Machine, bool MinGW,
+    ArrayRef<COFFShortExport> NativeExports = std::nullopt);
+
+} // namespace object
+} // namespace llvm
+
+#endif

--- a/reference/MathExtras.h
+++ b/reference/MathExtras.h
@@ -1,0 +1,649 @@
+//===-- llvm/Support/MathExtras.h - Useful math functions -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains some functions that are useful for math stuff.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_MATHEXTRAS_H
+#define LLVM_SUPPORT_MATHEXTRAS_H
+
+#include "llvm/ADT/bit.h"
+#include "llvm/Support/Compiler.h"
+#include <cassert>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+namespace llvm {
+
+/// Mathematical constants.
+namespace numbers {
+// TODO: Track C++20 std::numbers.
+// TODO: Favor using the hexadecimal FP constants (requires C++17).
+constexpr double e          = 2.7182818284590452354, // (0x1.5bf0a8b145749P+1) https://oeis.org/A001113
+                 egamma     = .57721566490153286061, // (0x1.2788cfc6fb619P-1) https://oeis.org/A001620
+                 ln2        = .69314718055994530942, // (0x1.62e42fefa39efP-1) https://oeis.org/A002162
+                 ln10       = 2.3025850929940456840, // (0x1.24bb1bbb55516P+1) https://oeis.org/A002392
+                 log2e      = 1.4426950408889634074, // (0x1.71547652b82feP+0)
+                 log10e     = .43429448190325182765, // (0x1.bcb7b1526e50eP-2)
+                 pi         = 3.1415926535897932385, // (0x1.921fb54442d18P+1) https://oeis.org/A000796
+                 inv_pi     = .31830988618379067154, // (0x1.45f306bc9c883P-2) https://oeis.org/A049541
+                 sqrtpi     = 1.7724538509055160273, // (0x1.c5bf891b4ef6bP+0) https://oeis.org/A002161
+                 inv_sqrtpi = .56418958354775628695, // (0x1.20dd750429b6dP-1) https://oeis.org/A087197
+                 sqrt2      = 1.4142135623730950488, // (0x1.6a09e667f3bcdP+0) https://oeis.org/A00219
+                 inv_sqrt2  = .70710678118654752440, // (0x1.6a09e667f3bcdP-1)
+                 sqrt3      = 1.7320508075688772935, // (0x1.bb67ae8584caaP+0) https://oeis.org/A002194
+                 inv_sqrt3  = .57735026918962576451, // (0x1.279a74590331cP-1)
+                 phi        = 1.6180339887498948482; // (0x1.9e3779b97f4a8P+0) https://oeis.org/A001622
+constexpr float ef          = 2.71828183F, // (0x1.5bf0a8P+1) https://oeis.org/A001113
+                egammaf     = .577215665F, // (0x1.2788d0P-1) https://oeis.org/A001620
+                ln2f        = .693147181F, // (0x1.62e430P-1) https://oeis.org/A002162
+                ln10f       = 2.30258509F, // (0x1.26bb1cP+1) https://oeis.org/A002392
+                log2ef      = 1.44269504F, // (0x1.715476P+0)
+                log10ef     = .434294482F, // (0x1.bcb7b2P-2)
+                pif         = 3.14159265F, // (0x1.921fb6P+1) https://oeis.org/A000796
+                inv_pif     = .318309886F, // (0x1.45f306P-2) https://oeis.org/A049541
+                sqrtpif     = 1.77245385F, // (0x1.c5bf8aP+0) https://oeis.org/A002161
+                inv_sqrtpif = .564189584F, // (0x1.20dd76P-1) https://oeis.org/A087197
+                sqrt2f      = 1.41421356F, // (0x1.6a09e6P+0) https://oeis.org/A002193
+                inv_sqrt2f  = .707106781F, // (0x1.6a09e6P-1)
+                sqrt3f      = 1.73205081F, // (0x1.bb67aeP+0) https://oeis.org/A002194
+                inv_sqrt3f  = .577350269F, // (0x1.279a74P-1)
+                phif        = 1.61803399F; // (0x1.9e377aP+0) https://oeis.org/A001622
+} // namespace numbers
+
+/// Create a bitmask with the N right-most bits set to 1, and all other
+/// bits set to 0.  Only unsigned types are allowed.
+template <typename T> T maskTrailingOnes(unsigned N) {
+  static_assert(std::is_unsigned_v<T>, "Invalid type!");
+  const unsigned Bits = CHAR_BIT * sizeof(T);
+  assert(N <= Bits && "Invalid bit index");
+  return N == 0 ? 0 : (T(-1) >> (Bits - N));
+}
+
+/// Create a bitmask with the N left-most bits set to 1, and all other
+/// bits set to 0.  Only unsigned types are allowed.
+template <typename T> T maskLeadingOnes(unsigned N) {
+  return ~maskTrailingOnes<T>(CHAR_BIT * sizeof(T) - N);
+}
+
+/// Create a bitmask with the N right-most bits set to 0, and all other
+/// bits set to 1.  Only unsigned types are allowed.
+template <typename T> T maskTrailingZeros(unsigned N) {
+  return maskLeadingOnes<T>(CHAR_BIT * sizeof(T) - N);
+}
+
+/// Create a bitmask with the N left-most bits set to 0, and all other
+/// bits set to 1.  Only unsigned types are allowed.
+template <typename T> T maskLeadingZeros(unsigned N) {
+  return maskTrailingOnes<T>(CHAR_BIT * sizeof(T) - N);
+}
+
+/// Macro compressed bit reversal table for 256 bits.
+///
+/// http://graphics.stanford.edu/~seander/bithacks.html#BitReverseTable
+static const unsigned char BitReverseTable256[256] = {
+#define R2(n) n, n + 2 * 64, n + 1 * 64, n + 3 * 64
+#define R4(n) R2(n), R2(n + 2 * 16), R2(n + 1 * 16), R2(n + 3 * 16)
+#define R6(n) R4(n), R4(n + 2 * 4), R4(n + 1 * 4), R4(n + 3 * 4)
+  R6(0), R6(2), R6(1), R6(3)
+#undef R2
+#undef R4
+#undef R6
+};
+
+/// Reverse the bits in \p Val.
+template <typename T> T reverseBits(T Val) {
+#if __has_builtin(__builtin_bitreverse8)
+  if constexpr (std::is_same_v<T, uint8_t>)
+    return __builtin_bitreverse8(Val);
+#endif
+#if __has_builtin(__builtin_bitreverse16)
+  if constexpr (std::is_same_v<T, uint16_t>)
+    return __builtin_bitreverse16(Val);
+#endif
+#if __has_builtin(__builtin_bitreverse32)
+  if constexpr (std::is_same_v<T, uint32_t>)
+    return __builtin_bitreverse32(Val);
+#endif
+#if __has_builtin(__builtin_bitreverse64)
+  if constexpr (std::is_same_v<T, uint64_t>)
+    return __builtin_bitreverse64(Val);
+#endif
+
+  unsigned char in[sizeof(Val)];
+  unsigned char out[sizeof(Val)];
+  std::memcpy(in, &Val, sizeof(Val));
+  for (unsigned i = 0; i < sizeof(Val); ++i)
+    out[(sizeof(Val) - i) - 1] = BitReverseTable256[in[i]];
+  std::memcpy(&Val, out, sizeof(Val));
+  return Val;
+}
+
+// NOTE: The following support functions use the _32/_64 extensions instead of
+// type overloading so that signed and unsigned integers can be used without
+// ambiguity.
+
+/// Return the high 32 bits of a 64 bit value.
+constexpr inline uint32_t Hi_32(uint64_t Value) {
+  return static_cast<uint32_t>(Value >> 32);
+}
+
+/// Return the low 32 bits of a 64 bit value.
+constexpr inline uint32_t Lo_32(uint64_t Value) {
+  return static_cast<uint32_t>(Value);
+}
+
+/// Make a 64-bit integer from a high / low pair of 32-bit integers.
+constexpr inline uint64_t Make_64(uint32_t High, uint32_t Low) {
+  return ((uint64_t)High << 32) | (uint64_t)Low;
+}
+
+/// Checks if an integer fits into the given bit width.
+template <unsigned N> constexpr inline bool isInt(int64_t x) {
+  if constexpr (N == 8)
+    return static_cast<int8_t>(x) == x;
+  if constexpr (N == 16)
+    return static_cast<int16_t>(x) == x;
+  if constexpr (N == 32)
+    return static_cast<int32_t>(x) == x;
+  if constexpr (N < 64)
+    return -(INT64_C(1) << (N - 1)) <= x && x < (INT64_C(1) << (N - 1));
+  (void)x; // MSVC v19.25 warns that x is unused.
+  return true;
+}
+
+/// Checks if a signed integer is an N bit number shifted left by S.
+template <unsigned N, unsigned S>
+constexpr inline bool isShiftedInt(int64_t x) {
+  static_assert(
+      N > 0, "isShiftedInt<0> doesn't make sense (refers to a 0-bit number.");
+  static_assert(N + S <= 64, "isShiftedInt<N, S> with N + S > 64 is too wide.");
+  return isInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
+}
+
+/// Checks if an unsigned integer fits into the given bit width.
+template <unsigned N> constexpr inline bool isUInt(uint64_t x) {
+  static_assert(N > 0, "isUInt<0> doesn't make sense");
+  if constexpr (N == 8)
+    return static_cast<uint8_t>(x) == x;
+  if constexpr (N == 16)
+    return static_cast<uint16_t>(x) == x;
+  if constexpr (N == 32)
+    return static_cast<uint32_t>(x) == x;
+  if constexpr (N < 64)
+    return x < (UINT64_C(1) << (N));
+  (void)x; // MSVC v19.25 warns that x is unused.
+  return true;
+}
+
+/// Checks if a unsigned integer is an N bit number shifted left by S.
+template <unsigned N, unsigned S>
+constexpr inline bool isShiftedUInt(uint64_t x) {
+  static_assert(
+      N > 0, "isShiftedUInt<0> doesn't make sense (refers to a 0-bit number)");
+  static_assert(N + S <= 64,
+                "isShiftedUInt<N, S> with N + S > 64 is too wide.");
+  // Per the two static_asserts above, S must be strictly less than 64.  So
+  // 1 << S is not undefined behavior.
+  return isUInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
+}
+
+/// Gets the maximum value for a N-bit unsigned integer.
+inline uint64_t maxUIntN(uint64_t N) {
+  assert(N > 0 && N <= 64 && "integer width out of range");
+
+  // uint64_t(1) << 64 is undefined behavior, so we can't do
+  //   (uint64_t(1) << N) - 1
+  // without checking first that N != 64.  But this works and doesn't have a
+  // branch.
+  return UINT64_MAX >> (64 - N);
+}
+
+/// Gets the minimum value for a N-bit signed integer.
+inline int64_t minIntN(int64_t N) {
+  assert(N > 0 && N <= 64 && "integer width out of range");
+
+  return UINT64_C(1) + ~(UINT64_C(1) << (N - 1));
+}
+
+/// Gets the maximum value for a N-bit signed integer.
+inline int64_t maxIntN(int64_t N) {
+  assert(N > 0 && N <= 64 && "integer width out of range");
+
+  // This relies on two's complement wraparound when N == 64, so we convert to
+  // int64_t only at the very end to avoid UB.
+  return (UINT64_C(1) << (N - 1)) - 1;
+}
+
+/// Checks if an unsigned integer fits into the given (dynamic) bit width.
+inline bool isUIntN(unsigned N, uint64_t x) {
+  return N >= 64 || x <= maxUIntN(N);
+}
+
+/// Checks if an signed integer fits into the given (dynamic) bit width.
+inline bool isIntN(unsigned N, int64_t x) {
+  return N >= 64 || (minIntN(N) <= x && x <= maxIntN(N));
+}
+
+/// Return true if the argument is a non-empty sequence of ones starting at the
+/// least significant bit with the remainder zero (32 bit version).
+/// Ex. isMask_32(0x0000FFFFU) == true.
+constexpr inline bool isMask_32(uint32_t Value) {
+  return Value && ((Value + 1) & Value) == 0;
+}
+
+/// Return true if the argument is a non-empty sequence of ones starting at the
+/// least significant bit with the remainder zero (64 bit version).
+constexpr inline bool isMask_64(uint64_t Value) {
+  return Value && ((Value + 1) & Value) == 0;
+}
+
+/// Return true if the argument contains a non-empty sequence of ones with the
+/// remainder zero (32 bit version.) Ex. isShiftedMask_32(0x0000FF00U) == true.
+constexpr inline bool isShiftedMask_32(uint32_t Value) {
+  return Value && isMask_32((Value - 1) | Value);
+}
+
+/// Return true if the argument contains a non-empty sequence of ones with the
+/// remainder zero (64 bit version.)
+constexpr inline bool isShiftedMask_64(uint64_t Value) {
+  return Value && isMask_64((Value - 1) | Value);
+}
+
+/// Return true if the argument is a power of two > 0.
+/// Ex. isPowerOf2_32(0x00100000U) == true (32 bit edition.)
+constexpr inline bool isPowerOf2_32(uint32_t Value) {
+  return llvm::has_single_bit(Value);
+}
+
+/// Return true if the argument is a power of two > 0 (64 bit edition.)
+constexpr inline bool isPowerOf2_64(uint64_t Value) {
+  return llvm::has_single_bit(Value);
+}
+
+/// Return true if the argument contains a non-empty sequence of ones with the
+/// remainder zero (32 bit version.) Ex. isShiftedMask_32(0x0000FF00U) == true.
+/// If true, \p MaskIdx will specify the index of the lowest set bit and \p
+/// MaskLen is updated to specify the length of the mask, else neither are
+/// updated.
+inline bool isShiftedMask_32(uint32_t Value, unsigned &MaskIdx,
+                             unsigned &MaskLen) {
+  if (!isShiftedMask_32(Value))
+    return false;
+  MaskIdx = llvm::countr_zero(Value);
+  MaskLen = llvm::popcount(Value);
+  return true;
+}
+
+/// Return true if the argument contains a non-empty sequence of ones with the
+/// remainder zero (64 bit version.) If true, \p MaskIdx will specify the index
+/// of the lowest set bit and \p MaskLen is updated to specify the length of the
+/// mask, else neither are updated.
+inline bool isShiftedMask_64(uint64_t Value, unsigned &MaskIdx,
+                             unsigned &MaskLen) {
+  if (!isShiftedMask_64(Value))
+    return false;
+  MaskIdx = llvm::countr_zero(Value);
+  MaskLen = llvm::popcount(Value);
+  return true;
+}
+
+/// Compile time Log2.
+/// Valid only for positive powers of two.
+template <size_t kValue> constexpr inline size_t CTLog2() {
+  static_assert(kValue > 0 && llvm::isPowerOf2_64(kValue),
+                "Value is not a valid power of 2");
+  return 1 + CTLog2<kValue / 2>();
+}
+
+template <> constexpr inline size_t CTLog2<1>() { return 0; }
+
+/// Return the floor log base 2 of the specified value, -1 if the value is zero.
+/// (32 bit edition.)
+/// Ex. Log2_32(32) == 5, Log2_32(1) == 0, Log2_32(0) == -1, Log2_32(6) == 2
+inline unsigned Log2_32(uint32_t Value) {
+  return 31 - llvm::countl_zero(Value);
+}
+
+/// Return the floor log base 2 of the specified value, -1 if the value is zero.
+/// (64 bit edition.)
+inline unsigned Log2_64(uint64_t Value) {
+  return 63 - llvm::countl_zero(Value);
+}
+
+/// Return the ceil log base 2 of the specified value, 32 if the value is zero.
+/// (32 bit edition).
+/// Ex. Log2_32_Ceil(32) == 5, Log2_32_Ceil(1) == 0, Log2_32_Ceil(6) == 3
+inline unsigned Log2_32_Ceil(uint32_t Value) {
+  return 32 - llvm::countl_zero(Value - 1);
+}
+
+/// Return the ceil log base 2 of the specified value, 64 if the value is zero.
+/// (64 bit edition.)
+inline unsigned Log2_64_Ceil(uint64_t Value) {
+  return 64 - llvm::countl_zero(Value - 1);
+}
+
+/// A and B are either alignments or offsets. Return the minimum alignment that
+/// may be assumed after adding the two together.
+constexpr inline uint64_t MinAlign(uint64_t A, uint64_t B) {
+  // The largest power of 2 that divides both A and B.
+  //
+  // Replace "-Value" by "1+~Value" in the following commented code to avoid
+  // MSVC warning C4146
+  //    return (A | B) & -(A | B);
+  return (A | B) & (1 + ~(A | B));
+}
+
+/// Returns the next power of two (in 64-bits) that is strictly greater than A.
+/// Returns zero on overflow.
+constexpr inline uint64_t NextPowerOf2(uint64_t A) {
+  A |= (A >> 1);
+  A |= (A >> 2);
+  A |= (A >> 4);
+  A |= (A >> 8);
+  A |= (A >> 16);
+  A |= (A >> 32);
+  return A + 1;
+}
+
+/// Returns the power of two which is greater than or equal to the given value.
+/// Essentially, it is a ceil operation across the domain of powers of two.
+inline uint64_t PowerOf2Ceil(uint64_t A) {
+  if (!A || A > UINT64_MAX / 2)
+    return 0;
+  return UINT64_C(1) << Log2_64_Ceil(A);
+}
+
+/// Returns the next integer (mod 2**64) that is greater than or equal to
+/// \p Value and is a multiple of \p Align. \p Align must be non-zero.
+///
+/// Examples:
+/// \code
+///   alignTo(5, 8) = 8
+///   alignTo(17, 8) = 24
+///   alignTo(~0LL, 8) = 0
+///   alignTo(321, 255) = 510
+/// \endcode
+inline uint64_t alignTo(uint64_t Value, uint64_t Align) {
+  assert(Align != 0u && "Align can't be 0.");
+  return (Value + Align - 1) / Align * Align;
+}
+
+inline uint64_t alignToPowerOf2(uint64_t Value, uint64_t Align) {
+  assert(Align != 0 && (Align & (Align - 1)) == 0 &&
+         "Align must be a power of 2");
+  // Replace unary minus to avoid compilation error on Windows:
+  // "unary minus operator applied to unsigned type, result still unsigned"
+  uint64_t negAlign = (~Align) + 1;
+  return (Value + Align - 1) & negAlign;
+}
+
+/// If non-zero \p Skew is specified, the return value will be a minimal integer
+/// that is greater than or equal to \p Size and equal to \p A * N + \p Skew for
+/// some integer N. If \p Skew is larger than \p A, its value is adjusted to '\p
+/// Skew mod \p A'. \p Align must be non-zero.
+///
+/// Examples:
+/// \code
+///   alignTo(5, 8, 7) = 7
+///   alignTo(17, 8, 1) = 17
+///   alignTo(~0LL, 8, 3) = 3
+///   alignTo(321, 255, 42) = 552
+/// \endcode
+inline uint64_t alignTo(uint64_t Value, uint64_t Align, uint64_t Skew) {
+  assert(Align != 0u && "Align can't be 0.");
+  Skew %= Align;
+  return alignTo(Value - Skew, Align) + Skew;
+}
+
+/// Returns the next integer (mod 2**64) that is greater than or equal to
+/// \p Value and is a multiple of \c Align. \c Align must be non-zero.
+template <uint64_t Align> constexpr inline uint64_t alignTo(uint64_t Value) {
+  static_assert(Align != 0u, "Align must be non-zero");
+  return (Value + Align - 1) / Align * Align;
+}
+
+/// Returns the integer ceil(Numerator / Denominator).
+inline uint64_t divideCeil(uint64_t Numerator, uint64_t Denominator) {
+  return alignTo(Numerator, Denominator) / Denominator;
+}
+
+/// Returns the integer nearest(Numerator / Denominator).
+inline uint64_t divideNearest(uint64_t Numerator, uint64_t Denominator) {
+  return (Numerator + (Denominator / 2)) / Denominator;
+}
+
+/// Returns the largest uint64_t less than or equal to \p Value and is
+/// \p Skew mod \p Align. \p Align must be non-zero
+inline uint64_t alignDown(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
+  assert(Align != 0u && "Align can't be 0.");
+  Skew %= Align;
+  return (Value - Skew) / Align * Align + Skew;
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 32-bit integer.
+/// Requires 0 < B <= 32.
+template <unsigned B> constexpr inline int32_t SignExtend32(uint32_t X) {
+  static_assert(B > 0, "Bit width can't be 0.");
+  static_assert(B <= 32, "Bit width out of range.");
+  return int32_t(X << (32 - B)) >> (32 - B);
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 32-bit integer.
+/// Requires 0 < B <= 32.
+inline int32_t SignExtend32(uint32_t X, unsigned B) {
+  assert(B > 0 && "Bit width can't be 0.");
+  assert(B <= 32 && "Bit width out of range.");
+  return int32_t(X << (32 - B)) >> (32 - B);
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 64-bit integer.
+/// Requires 0 < B <= 64.
+template <unsigned B> constexpr inline int64_t SignExtend64(uint64_t x) {
+  static_assert(B > 0, "Bit width can't be 0.");
+  static_assert(B <= 64, "Bit width out of range.");
+  return int64_t(x << (64 - B)) >> (64 - B);
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 64-bit integer.
+/// Requires 0 < B <= 64.
+inline int64_t SignExtend64(uint64_t X, unsigned B) {
+  assert(B > 0 && "Bit width can't be 0.");
+  assert(B <= 64 && "Bit width out of range.");
+  return int64_t(X << (64 - B)) >> (64 - B);
+}
+
+/// Subtract two unsigned integers, X and Y, of type T and return the absolute
+/// value of the result.
+template <typename T>
+std::enable_if_t<std::is_unsigned_v<T>, T> AbsoluteDifference(T X, T Y) {
+  return X > Y ? (X - Y) : (Y - X);
+}
+
+/// Add two unsigned integers, X and Y, of type T.  Clamp the result to the
+/// maximum representable value of T on overflow.  ResultOverflowed indicates if
+/// the result is larger than the maximum representable value of type T.
+template <typename T>
+std::enable_if_t<std::is_unsigned_v<T>, T>
+SaturatingAdd(T X, T Y, bool *ResultOverflowed = nullptr) {
+  bool Dummy;
+  bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
+  // Hacker's Delight, p. 29
+  T Z = X + Y;
+  Overflowed = (Z < X || Z < Y);
+  if (Overflowed)
+    return std::numeric_limits<T>::max();
+  else
+    return Z;
+}
+
+/// Add multiple unsigned integers of type T.  Clamp the result to the
+/// maximum representable value of T on overflow.
+template <class T, class... Ts>
+std::enable_if_t<std::is_unsigned_v<T>, T> SaturatingAdd(T X, T Y, T Z,
+                                                         Ts... Args) {
+  bool Overflowed = false;
+  T XY = SaturatingAdd(X, Y, &Overflowed);
+  if (Overflowed)
+    return SaturatingAdd(std::numeric_limits<T>::max(), T(1), Args...);
+  return SaturatingAdd(XY, Z, Args...);
+}
+
+/// Multiply two unsigned integers, X and Y, of type T.  Clamp the result to the
+/// maximum representable value of T on overflow.  ResultOverflowed indicates if
+/// the result is larger than the maximum representable value of type T.
+template <typename T>
+std::enable_if_t<std::is_unsigned_v<T>, T>
+SaturatingMultiply(T X, T Y, bool *ResultOverflowed = nullptr) {
+  bool Dummy;
+  bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
+
+  // Hacker's Delight, p. 30 has a different algorithm, but we don't use that
+  // because it fails for uint16_t (where multiplication can have undefined
+  // behavior due to promotion to int), and requires a division in addition
+  // to the multiplication.
+
+  Overflowed = false;
+
+  // Log2(Z) would be either Log2Z or Log2Z + 1.
+  // Special case: if X or Y is 0, Log2_64 gives -1, and Log2Z
+  // will necessarily be less than Log2Max as desired.
+  int Log2Z = Log2_64(X) + Log2_64(Y);
+  const T Max = std::numeric_limits<T>::max();
+  int Log2Max = Log2_64(Max);
+  if (Log2Z < Log2Max) {
+    return X * Y;
+  }
+  if (Log2Z > Log2Max) {
+    Overflowed = true;
+    return Max;
+  }
+
+  // We're going to use the top bit, and maybe overflow one
+  // bit past it. Multiply all but the bottom bit then add
+  // that on at the end.
+  T Z = (X >> 1) * Y;
+  if (Z & ~(Max >> 1)) {
+    Overflowed = true;
+    return Max;
+  }
+  Z <<= 1;
+  if (X & 1)
+    return SaturatingAdd(Z, Y, ResultOverflowed);
+
+  return Z;
+}
+
+/// Multiply two unsigned integers, X and Y, and add the unsigned integer, A to
+/// the product. Clamp the result to the maximum representable value of T on
+/// overflow. ResultOverflowed indicates if the result is larger than the
+/// maximum representable value of type T.
+template <typename T>
+std::enable_if_t<std::is_unsigned_v<T>, T>
+SaturatingMultiplyAdd(T X, T Y, T A, bool *ResultOverflowed = nullptr) {
+  bool Dummy;
+  bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
+
+  T Product = SaturatingMultiply(X, Y, &Overflowed);
+  if (Overflowed)
+    return Product;
+
+  return SaturatingAdd(A, Product, &Overflowed);
+}
+
+/// Use this rather than HUGE_VALF; the latter causes warnings on MSVC.
+extern const float huge_valf;
+
+
+/// Add two signed integers, computing the two's complement truncated result,
+/// returning true if overflow occurred.
+template <typename T>
+std::enable_if_t<std::is_signed_v<T>, T> AddOverflow(T X, T Y, T &Result) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(X, Y, &Result);
+#else
+  // Perform the unsigned addition.
+  using U = std::make_unsigned_t<T>;
+  const U UX = static_cast<U>(X);
+  const U UY = static_cast<U>(Y);
+  const U UResult = UX + UY;
+
+  // Convert to signed.
+  Result = static_cast<T>(UResult);
+
+  // Adding two positive numbers should result in a positive number.
+  if (X > 0 && Y > 0)
+    return Result <= 0;
+  // Adding two negatives should result in a negative number.
+  if (X < 0 && Y < 0)
+    return Result >= 0;
+  return false;
+#endif
+}
+
+/// Subtract two signed integers, computing the two's complement truncated
+/// result, returning true if an overflow ocurred.
+template <typename T>
+std::enable_if_t<std::is_signed_v<T>, T> SubOverflow(T X, T Y, T &Result) {
+#if __has_builtin(__builtin_sub_overflow)
+  return __builtin_sub_overflow(X, Y, &Result);
+#else
+  // Perform the unsigned addition.
+  using U = std::make_unsigned_t<T>;
+  const U UX = static_cast<U>(X);
+  const U UY = static_cast<U>(Y);
+  const U UResult = UX - UY;
+
+  // Convert to signed.
+  Result = static_cast<T>(UResult);
+
+  // Subtracting a positive number from a negative results in a negative number.
+  if (X <= 0 && Y > 0)
+    return Result >= 0;
+  // Subtracting a negative number from a positive results in a positive number.
+  if (X >= 0 && Y < 0)
+    return Result <= 0;
+  return false;
+#endif
+}
+
+/// Multiply two signed integers, computing the two's complement truncated
+/// result, returning true if an overflow ocurred.
+template <typename T>
+std::enable_if_t<std::is_signed_v<T>, T> MulOverflow(T X, T Y, T &Result) {
+  // Perform the unsigned multiplication on absolute values.
+  using U = std::make_unsigned_t<T>;
+  const U UX = X < 0 ? (0 - static_cast<U>(X)) : static_cast<U>(X);
+  const U UY = Y < 0 ? (0 - static_cast<U>(Y)) : static_cast<U>(Y);
+  const U UResult = UX * UY;
+
+  // Convert to signed.
+  const bool IsNegative = (X < 0) ^ (Y < 0);
+  Result = IsNegative ? (0 - UResult) : UResult;
+
+  // If any of the args was 0, result is 0 and no overflow occurs.
+  if (UX == 0 || UY == 0)
+    return false;
+
+  // UX and UY are in [1, 2^n], where n is the number of digits.
+  // Check how the max allowed absolute value (2^n for negative, 2^(n-1) for
+  // positive) divided by an argument compares to the other.
+  if (IsNegative)
+    return UX > (static_cast<U>(std::numeric_limits<T>::max()) + U(1)) / UY;
+  else
+    return UX > (static_cast<U>(std::numeric_limits<T>::max())) / UY;
+}
+
+} // End llvm namespace
+
+#endif

--- a/reference/Readme.md
+++ b/reference/Readme.md
@@ -3,12 +3,14 @@
 These are a copy of the relevant LLVM files that were ported to Rust from the
 last time that this project was "synced" with LLVM.
 
-Currently that sync point is 15.0.0-rc3, commit [8ef3e895a](https://github.com/llvm/llvm-project/tree/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2).
+Currently that sync point is 18.1.3, commit [ef6d1ec](https://github.com/llvm/llvm-project/tree/ef6d1ec07c693352c4a60dd58db08d2d8558f6ea).
 
 These files were originally located at:
-* `llvm/include/llvm/Support/Alignment.h`
 * `llvm/include/llvm/Object/Archive.h`
 * `llvm/include/llvm/Object/ArchiveWriter.h`
+* `llvm/include/llvm/Object/COFFImportFile.h`
+* `llvm/include/llvm/Support/Alignment.h`
+* `llvm/include/llvm/Support/MathExtras.h`
 * `llvm/lib/Object/ArchiveWriter.cpp`
 
 When syncing, make sure to update these files and the commit above.

--- a/reference/Readme.md
+++ b/reference/Readme.md
@@ -1,0 +1,18 @@
+# LLVM Reference Files
+
+These are a copy of the relevant LLVM files that were ported to Rust from the
+last time that this project was "synced" with LLVM.
+
+Currently that sync point is 15.0.0-rc3, commit [8ef3e895a](https://github.com/llvm/llvm-project/tree/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2).
+
+These files were originally located at:
+* `llvm/include/llvm/Support/Alignment.h`
+* `llvm/include/llvm/Object/Archive.h`
+* `llvm/include/llvm/Object/ArchiveWriter.h`
+* `llvm/lib/Object/ArchiveWriter.cpp`
+
+When syncing, make sure to update these files and the commit above.
+
+Additionally, `ar_archive_writer` has removed some options, so you can assume:
+* `deterministic` is always `true`.
+* `write_symtab` is always `true`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "stable"
+# FIXME: LLVM 18 is in Rust 1.78, which is currently beta.
+channel = "beta"
 components = ["llvm-tools"]

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -3,8 +3,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Derived from https://github.com/llvm/llvm-project/blob/8ef3e895ad8ab1724e2b87cabad1dacdc7a397a3/llvm/include/llvm/Support/Alignment.h
-
 /// Returns a multiple of `align` needed to store `size` bytes.
 pub(crate) fn align_to(size: u64, align: u64) -> u64 {
     (size + align - 1) & !(align - 1)

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -3,8 +3,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Derived from https://github.com/llvm/llvm-project/blob/8ef3e895ad8ab1724e2b87cabad1dacdc7a397a3/llvm/include/llvm/Object/Archive.h
-
 /// Size field is 10 decimal digits long
 pub(crate) const MAX_MEMBER_SIZE: u64 = 9999999999;
 

--- a/src/archive_writer.rs
+++ b/src/archive_writer.rs
@@ -5,10 +5,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Derived from:
-// * https://github.com/llvm/llvm-project/blob/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2/llvm/include/llvm/Object/ArchiveWriter.h
-// * https://github.com/llvm/llvm-project/blob/3d3ef9d073e1e27ea57480b371b7f5a9f5642ed2/llvm/lib/Object/ArchiveWriter.cpp
-
 use std::collections::HashMap;
 use std::io::{self, Cursor, Seek, Write};
 

--- a/src/archive_writer.rs
+++ b/src/archive_writer.rs
@@ -5,17 +5,35 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{self, Cursor, Seek, Write};
-
-use object::{Object, ObjectSymbol};
+use std::mem::size_of;
 
 use crate::alignment::*;
 use crate::archive::*;
+use crate::coff_import_file;
+use crate::math_extras::align_to_power_of2;
+use crate::ObjectReader;
+
+const BIG_AR_MEM_HDR_SIZE: u64 = {
+    // `try_into` is not const, so check the size manually.
+    assert!(
+        std::mem::size_of::<usize>() <= std::mem::size_of::<u64>()
+            || std::mem::size_of::<big_archive::BigArMemHdrType>() < u64::MAX as usize
+    );
+    std::mem::size_of::<big_archive::BigArMemHdrType>() as u64
+};
+
+#[derive(Default)]
+struct SymMap {
+    use_ec_map: bool,
+    map: BTreeMap<Box<[u8]>, u16>,
+    ec_map: BTreeMap<Box<[u8]>, u16>,
+}
 
 pub struct NewArchiveMember<'a> {
     pub buf: Box<dyn AsRef<[u8]> + 'a>,
-    pub get_symbols: fn(buf: &[u8], f: &mut dyn FnMut(&[u8]) -> io::Result<()>) -> io::Result<bool>,
+    pub object_reader: &'static ObjectReader,
     pub member_name: String,
     pub mtime: u64,
     pub uid: u32,
@@ -31,11 +49,14 @@ fn is_aix_big_archive(kind: ArchiveKind) -> bool {
     kind == ArchiveKind::AixBig
 }
 
+fn is_coff_archive(kind: ArchiveKind) -> bool {
+    kind == ArchiveKind::Coff
+}
+
 fn is_bsd_like(kind: ArchiveKind) -> bool {
     match kind {
-        ArchiveKind::Gnu | ArchiveKind::Gnu64 | ArchiveKind::AixBig => false,
+        ArchiveKind::Gnu | ArchiveKind::Gnu64 | ArchiveKind::AixBig | ArchiveKind::Coff => false,
         ArchiveKind::Bsd | ArchiveKind::Darwin | ArchiveKind::Darwin64 => true,
-        ArchiveKind::Coff => panic!("not supported for writing"),
     }
 }
 
@@ -178,13 +199,16 @@ fn print_member_header<'m, W: Write, T: Write + Seek>(
     if thin {
         name_pos = string_table.stream_position()?;
         write!(string_table, "{}/\n", m.member_name)?;
+    } else if let Some(&pos) = member_names.get(&*m.member_name) {
+        name_pos = pos;
     } else {
-        if let Some(&pos) = member_names.get(&*m.member_name) {
-            name_pos = pos;
+        name_pos = string_table.stream_position()?;
+        member_names.insert(&m.member_name, name_pos);
+        write!(string_table, "{}", m.member_name)?;
+        if is_coff_archive(kind) {
+            write!(string_table, "\0")?;
         } else {
-            name_pos = string_table.stream_position()?;
-            member_names.insert(&m.member_name, name_pos);
-            write!(string_table, "{}/\n", m.member_name)?;
+            write!(string_table, "/\n")?;
         }
     }
     write!(w, "{:<15}", name_pos)?;
@@ -196,6 +220,8 @@ struct MemberData<'a> {
     header: Vec<u8>,
     data: &'a [u8],
     padding: &'static [u8],
+    pre_head_pad_size: u64,
+    object_reader: &'static ObjectReader,
 }
 
 fn compute_string_table(names: &[u8]) -> MemberData<'_> {
@@ -210,6 +236,8 @@ fn compute_string_table(names: &[u8]) -> MemberData<'_> {
         header,
         data: names,
         padding: if pad != 0 { b"\n" } else { b"" },
+        pre_head_pad_size: 0,
+        object_reader: &crate::DEFAULT_OBJECT_READER,
     }
 }
 
@@ -217,22 +245,7 @@ const fn now() -> u64 {
     0
 }
 
-fn is_archive_symbol(sym: &object::read::Symbol<'_, '_>) -> bool {
-    // FIXME Use a better equivalent of LLVM's SymbolRef::SF_FormatSpecific
-    if sym.kind() == object::SymbolKind::Null
-        || sym.kind() == object::SymbolKind::File
-        || sym.kind() == object::SymbolKind::Section
-    {
-        return false;
-    }
-    if !sym.is_global() {
-        return false;
-    }
-    if sym.is_undefined() {
-        return false;
-    }
-    true
-}
+// NOTE: isArchiveSymbol was moved to object_reader.rs
 
 fn print_n_bits<W: Write>(w: &mut W, kind: ArchiveKind, val: u64) -> io::Result<()> {
     if is_64bit_kind(kind) {
@@ -254,7 +267,7 @@ fn compute_symbol_table_size_and_pad(
     kind: ArchiveKind,
     num_syms: u64,
     offset_size: u64,
-    string_table: &[u8],
+    string_table_size: u64,
 ) -> (u64, u64) {
     assert!(
         offset_size == 4 || offset_size == 8,
@@ -269,7 +282,7 @@ fn compute_symbol_table_size_and_pad(
     if is_bsd_like(kind) {
         size += offset_size; // byte count;
     }
-    size += u64::try_from(string_table.len()).unwrap();
+    size += string_table_size;
     // ld64 expects the members to be 8-byte aligned for 64-bit content and at
     // least 4-byte aligned for 32-bit content.  Opt for the larger encoding
     // uniformly.
@@ -283,11 +296,39 @@ fn compute_symbol_table_size_and_pad(
     (size, pad)
 }
 
+fn compute_symbol_map_size_and_pad(num_obj: usize, sym_map: &SymMap) -> (u64, u64) {
+    let mut size = size_of::<u32>() * 2; // Number of symbols and objects entries
+    size += num_obj * size_of::<u32>(); // Offset table
+
+    for name in sym_map.map.keys() {
+        size += size_of::<u16>() + name.len() + 1;
+    }
+
+    let mut size = u64::try_from(size).unwrap();
+    let pad = offset_to_alignment(size, 2);
+    size += pad;
+    (size, pad)
+}
+
+fn compute_ec_symbols_size_and_pad(sym_map: &SymMap) -> (u64, u64) {
+    let mut size = size_of::<u32>(); // Number of symbols
+
+    for name in sym_map.ec_map.keys() {
+        size += size_of::<u16>() + name.len() + 1;
+    }
+
+    let mut size = u64::try_from(size).unwrap();
+    let pad = offset_to_alignment(size, 2);
+    size += pad;
+    (size, pad)
+}
+
 fn write_symbol_table_header<W: Write + Seek>(
     w: &mut W,
     kind: ArchiveKind,
     size: u64,
     prev_member_offset: u64,
+    next_member_offset: u64,
 ) -> io::Result<()> {
     if is_bsd_like(kind) {
         let name = if is_64bit_kind(kind) {
@@ -298,37 +339,80 @@ fn write_symbol_table_header<W: Write + Seek>(
         let pos = w.stream_position()?;
         print_bsd_member_header(w, pos, name, now(), 0, 0, 0, size)
     } else if is_aix_big_archive(kind) {
-        print_big_archive_member_header(w, "", now(), 0, 0, 0, size, prev_member_offset, 0)
+        print_big_archive_member_header(
+            w,
+            "",
+            now(),
+            0,
+            0,
+            0,
+            size,
+            prev_member_offset,
+            next_member_offset,
+        )
     } else {
         let name = if is_64bit_kind(kind) { "/SYM64" } else { "" };
         print_gnu_small_member_header(w, name.to_string(), now(), 0, 0, 0, size)
     }
 }
 
+fn compute_headers_size(
+    kind: ArchiveKind,
+    num_members: usize,
+    string_member_size: u64,
+    num_syms: u64,
+    sym_names_size: u64,
+    sym_map: Option<&SymMap>,
+) -> io::Result<u64> {
+    let offset_size = if is_64bit_kind(kind) { 8 } else { 4 };
+    let (symtab_size, _) =
+        compute_symbol_table_size_and_pad(kind, num_syms, offset_size, sym_names_size);
+    let compute_symbol_table_header_size = || -> io::Result<u64> {
+        let mut tmp = Cursor::new(Vec::new());
+        write_symbol_table_header(&mut tmp, kind, symtab_size, 0, 0)?;
+        Ok(tmp.into_inner().len().try_into().unwrap())
+    };
+    let header_size = compute_symbol_table_header_size()?;
+    let mut size = u64::try_from("!<arch>\n".len()).unwrap() + header_size + symtab_size;
+
+    if let Some(sym_map) = sym_map {
+        size += header_size + compute_symbol_map_size_and_pad(num_members, sym_map).0;
+        if !sym_map.ec_map.is_empty() {
+            size += header_size + compute_ec_symbols_size_and_pad(sym_map).0;
+        }
+    }
+
+    Ok(size + string_member_size)
+}
+
+// NOTE: is64BitSymbolicFile, getAuxMaxAlignment and getMemberAlignment were
+// moved to object_reader.rs
+
 fn write_symbol_table<W: Write + Seek>(
     w: &mut W,
     kind: ArchiveKind,
     members: &[MemberData<'_>],
     string_table: &[u8],
+    members_offset: u64,
+    num_syms: u64,
     prev_member_offset: u64,
+    next_member_offset: u64,
+    is_64_bit: bool,
 ) -> io::Result<()> {
     // We don't write a symbol table on an archive with no members -- except on
     // Darwin, where the linker will abort unless the archive has a symbol table.
-    if string_table.is_empty() && !is_darwin(kind) {
+    if string_table.is_empty() && !is_darwin(kind) && !is_coff_archive(kind) {
         return Ok(());
     }
 
-    let num_syms = u64::try_from(members.iter().map(|m| m.symbols.len()).sum::<usize>()).unwrap();
-
     let offset_size = if is_64bit_kind(kind) { 8 } else { 4 };
-    let (size, pad) = compute_symbol_table_size_and_pad(kind, num_syms, offset_size, string_table);
-    write_symbol_table_header(w, kind, size, prev_member_offset)?;
-
-    let mut pos = if is_aix_big_archive(kind) {
-        u64::try_from(std::mem::size_of::<big_archive::FixLenHdr>()).unwrap()
-    } else {
-        w.stream_position()? + size
-    };
+    let (size, pad) = compute_symbol_table_size_and_pad(
+        kind,
+        num_syms,
+        offset_size,
+        string_table.len().try_into().unwrap(),
+    );
+    write_symbol_table_header(w, kind, size, prev_member_offset, next_member_offset)?;
 
     if is_bsd_like(kind) {
         print_n_bits(w, kind, num_syms * 2 * offset_size)?;
@@ -336,7 +420,16 @@ fn write_symbol_table<W: Write + Seek>(
         print_n_bits(w, kind, num_syms)?;
     }
 
+    let mut pos = members_offset;
     for m in members {
+        if is_aix_big_archive(kind) {
+            pos += m.pre_head_pad_size;
+            if (m.object_reader.is_64_bit_object_file)(m.data) != is_64_bit {
+                pos += u64::try_from(m.header.len() + m.data.len() + m.padding.len()).unwrap();
+                continue;
+            }
+        }
+
         for &string_offset in &m.symbols {
             if is_bsd_like(kind) {
                 print_n_bits(w, kind, string_offset)?;
@@ -361,45 +454,132 @@ fn write_symbol_table<W: Write + Seek>(
     )
 }
 
-pub fn get_native_object_symbols(
-    buf: &[u8],
-    f: &mut dyn FnMut(&[u8]) -> io::Result<()>,
-) -> io::Result<bool> {
-    // FIXME match what LLVM does
+fn write_symbol_map<W: Write + Seek>(
+    w: &mut W,
+    kind: ArchiveKind,
+    members: &[MemberData],
+    sym_map: &SymMap,
+    members_offset: u64,
+) -> io::Result<()> {
+    let (size, pad) = compute_symbol_map_size_and_pad(members.len(), sym_map);
+    write_symbol_table_header(w, kind, size, 0, 0)?;
 
-    match object::File::parse(buf) {
-        Ok(file) => {
-            for sym in file.symbols() {
-                if !is_archive_symbol(&sym) {
-                    continue;
-                }
-                f(sym.name_bytes().expect("FIXME"))?;
-            }
-            Ok(true)
-        }
-        Err(_) => Ok(false),
+    let mut pos: u32 = members_offset.try_into().unwrap();
+
+    w.write_all(&u32::try_from(members.len()).unwrap().to_le_bytes())?;
+    for m in members {
+        w.write_all(&pos.to_le_bytes())?; // member offset
+        pos = pos
+            .checked_add(
+                (m.header.len() + m.data.len() + m.padding.len())
+                    .try_into()
+                    .unwrap(),
+            )
+            .unwrap();
     }
+
+    w.write_all(&u32::try_from(sym_map.map.len()).unwrap().to_le_bytes())?;
+
+    for s in sym_map.map.values() {
+        w.write_all(&s.to_le_bytes())?;
+    }
+    for s in sym_map.map.keys() {
+        w.write_all(s)?;
+        w.write_all(&[0])?;
+    }
+
+    write!(
+        w,
+        "{nil:\0<pad$}",
+        nil = "",
+        pad = usize::try_from(pad).unwrap()
+    )?;
+    Ok(())
 }
 
-// NOTE: LLVM calls this getSymbols and has the get_native_symbols function inlined
+fn write_ec_symbols<W: Write + Seek>(w: &mut W, sym_map: &SymMap) -> io::Result<()> {
+    let (size, pad) = compute_ec_symbols_size_and_pad(sym_map);
+    print_gnu_small_member_header(w, "/<ECSYMBOLS>".to_string(), now(), 0, 0, 0, size)?;
+
+    w.write_all(&u32::try_from(sym_map.ec_map.len()).unwrap().to_le_bytes())?;
+
+    for s in sym_map.ec_map.values() {
+        w.write_all(&s.to_le_bytes())?;
+    }
+    for s in sym_map.ec_map.keys() {
+        w.write_all(s)?;
+        w.write_all(&[0])?;
+    }
+
+    write!(
+        w,
+        "{nil:\0<pad$}",
+        nil = "",
+        pad = usize::try_from(pad).unwrap()
+    )?;
+    Ok(())
+}
+
+// NOTE: isECObject was moved to object_reader.rs
+
+fn is_import_descriptor(name: &[u8]) -> bool {
+    name.starts_with(coff_import_file::IMPORT_DESCRIPTOR_PREFIX)
+        || name == coff_import_file::NULL_IMPORT_DESCRIPTOR_SYMBOL_NAME
+        || (name.starts_with(coff_import_file::NULL_THUNK_DATA_PREFIX)
+            && name.ends_with(coff_import_file::NULL_THUNK_DATA_SUFFIX))
+}
+
+// NOTE: LLVM calls this getSymbols and has the get_native_object_symbols
+// function (moved to object_reader.rs) inlined.
 fn write_symbols(
-    buf: &[u8],
-    get_symbols: fn(buf: &[u8], f: &mut dyn FnMut(&[u8]) -> io::Result<()>) -> io::Result<bool>,
+    obj: &[u8],
+    index: u16,
     sym_names: &mut Cursor<Vec<u8>>,
-    has_object: &mut bool,
+    sym_map: &mut Option<&mut SymMap>,
+    object_reader: &ObjectReader,
 ) -> io::Result<Vec<u64>> {
     let mut ret = vec![];
-    // We only set has_object if get_symbols determines it's looking at an
-    // object file. This is because if we're creating an rlib, the archive will
-    // always end in lib.rmeta, and cause has_object to always become false.
-    if get_symbols(buf, &mut |sym| {
-        ret.push(sym_names.stream_position()?);
-        sym_names.write_all(sym)?;
-        sym_names.write_all(&[0])?;
+
+    let mut is_using_map = false;
+    let (mut map, mut ec_map) = if let Some(sym_map) = sym_map {
+        if sym_map.use_ec_map && (object_reader.is_ec_object_file)(obj) {
+            (Some(&mut sym_map.ec_map), None)
+        } else {
+            is_using_map = true;
+            (Some(&mut sym_map.map), Some(&mut sym_map.ec_map))
+        }
+    } else {
+        (None, None)
+    };
+
+    (object_reader.get_symbols)(obj, &mut |name| {
+        if let Some(map) = &mut map {
+            let entry = map.entry(name.to_vec().into_boxed_slice());
+            if matches!(entry, std::collections::btree_map::Entry::Occupied(_)) {
+                return Ok(()); // ignore duplicated symbol
+            }
+            entry.or_insert(index);
+
+            if is_using_map {
+                ret.push(sym_names.stream_position()?);
+                sym_names.write_all(name)?;
+                sym_names.write_all(&[0])?;
+
+                // If EC is enabled, then the import descriptors are NOT put into EC
+                // objects so we need to copy them to the EC map manually.
+                if let Some(ec_map) = &mut ec_map {
+                    if is_import_descriptor(name) {
+                        ec_map.insert(name.to_vec().into_boxed_slice(), index);
+                    }
+                }
+            }
+        } else {
+            ret.push(sym_names.stream_position()?);
+            sym_names.write_all(name)?;
+            sym_names.write_all(&[0])?;
+        }
         Ok(())
-    })? {
-        *has_object = true;
-    }
+    })?;
     Ok(ret)
 }
 
@@ -408,10 +588,12 @@ fn compute_member_data<'a, S: Write + Seek>(
     sym_names: &mut Cursor<Vec<u8>>,
     kind: ArchiveKind,
     thin: bool,
+    sym_map: &mut Option<&mut SymMap>,
     new_members: &'a [NewArchiveMember<'a>],
 ) -> io::Result<Vec<MemberData<'a>>> {
     const PADDING_DATA: &[u8; 8] = &[b'\n'; 8];
 
+    let mut mem_head_pad_size = 0;
     // This ignores the symbol table, but we only need the value mod 8 and the
     // symbol table is aligned to be a multiple of 8 bytes
     let mut pos = if is_aix_big_archive(kind) {
@@ -431,7 +613,7 @@ fn compute_member_data<'a, S: Write + Seek>(
     // UniqueTimestamps is a special case to improve debugging on Darwin:
     //
     // The Darwin linker does not link debug info into the final
-    // binary. Instead, it emits entries of type N_OSO in in the output
+    // binary. Instead, it emits entries of type N_OSO in the output
     // binary's symbol table, containing references to the linked-in
     // object files. Using that reference, the debugger can read the
     // debug data directly from the object files. Alternatively, an
@@ -483,11 +665,15 @@ fn compute_member_data<'a, S: Write + Seek>(
     // The big archive format needs to know the offset of the previous member
     // header.
     let mut prev_offset = 0;
+    let mut next_mem_head_pad_size = 0;
+    let mut index = 0;
     for m in new_members {
         let mut header = Vec::new();
 
         let buf = m.buf.as_ref().as_ref();
         let data = if thin { &[][..] } else { buf };
+
+        index += 1;
 
         // ld64 expects the members to be 8-byte aligned for 64-bit content and at
         // least 4-byte aligned for 32-bit content.  Opt for the larger encoding
@@ -518,11 +704,42 @@ fn compute_member_data<'a, S: Write + Seek>(
             ));
         }
 
+        // In the big archive file format, we need to calculate and include the next
+        // member offset and previous member offset in the file member header.
         if is_aix_big_archive(kind) {
-            let next_offset = pos
-                + u64::try_from(std::mem::size_of::<big_archive::BigArMemHdrType>()).unwrap()
+            let offset_to_mem_data =
+                pos + BIG_AR_MEM_HDR_SIZE + align_to(m.member_name.len().try_into().unwrap(), 2);
+
+            if index == 1 {
+                next_mem_head_pad_size = align_to_power_of2(
+                    offset_to_mem_data,
+                    (m.object_reader.get_xcoff_member_alignment)(buf).into(),
+                ) - offset_to_mem_data;
+            }
+
+            mem_head_pad_size = next_mem_head_pad_size;
+            pos += mem_head_pad_size;
+            let mut next_offset = pos
+                + BIG_AR_MEM_HDR_SIZE
                 + align_to(u64::try_from(m.member_name.len()).unwrap(), 2)
                 + align_to(size, 2);
+
+            // If there is another member file after this, we need to calculate the
+            // padding before the header.
+            if index != new_members.len() {
+                let offset_to_next_mem_data = next_offset
+                    + BIG_AR_MEM_HDR_SIZE
+                    + align_to(new_members[index].member_name.len().try_into().unwrap(), 2);
+                next_mem_head_pad_size = align_to_power_of2(
+                    offset_to_next_mem_data,
+                    (m.object_reader.get_xcoff_member_alignment)(
+                        new_members[index].buf.as_ref().as_ref(),
+                    )
+                    .into(),
+                ) - offset_to_next_mem_data;
+                next_offset += next_mem_head_pad_size;
+            }
+
             print_big_archive_member_header(
                 &mut header,
                 &m.member_name,
@@ -549,7 +766,14 @@ fn compute_member_data<'a, S: Write + Seek>(
             )?;
         }
 
-        let symbols = write_symbols(buf, m.get_symbols, sym_names, &mut has_object)?;
+        let symbols = write_symbols(
+            buf,
+            index.try_into().unwrap(),
+            sym_names,
+            sym_map,
+            m.object_reader,
+        )?;
+        has_object = true;
 
         pos += u64::try_from(header.len() + data.len() + padding.len()).unwrap();
         ret.push(MemberData {
@@ -557,24 +781,27 @@ fn compute_member_data<'a, S: Write + Seek>(
             header,
             data,
             padding,
+            pre_head_pad_size: mem_head_pad_size,
+            object_reader: m.object_reader,
         })
     }
 
     // If there are no symbols, emit an empty symbol table, to satisfy Solaris
     // tools, older versions of which expect a symbol table in a non-empty
     // archive, regardless of whether there are any symbols in it.
-    if has_object && sym_names.stream_position()? == 0 {
+    if has_object && sym_names.stream_position()? == 0 && !is_coff_archive(kind) {
         write!(sym_names, "\0\0\0")?;
     }
 
     Ok(ret)
 }
 
-pub fn write_archive_to_stream<W: Write + Seek>(
+pub fn write_archive_to_stream<'a, W: Write + Seek>(
     w: &mut W,
-    new_members: &[NewArchiveMember<'_>],
+    new_members: &'a [NewArchiveMember<'a>],
     mut kind: ArchiveKind,
     thin: bool,
+    is_ec: bool,
 ) -> io::Result<()> {
     assert!(
         !thin || !is_bsd_like(kind),
@@ -583,44 +810,80 @@ pub fn write_archive_to_stream<W: Write + Seek>(
 
     let mut sym_names = Cursor::new(Vec::new());
     let mut string_table = Cursor::new(Vec::new());
+    let mut sym_map = SymMap::default();
 
-    let mut data = compute_member_data(&mut string_table, &mut sym_names, kind, thin, new_members)?;
+    // COFF symbol map uses 16-bit indexes, so we can't use it if there are too
+    // many members.
+    if is_coff_archive(kind) && new_members.len() > 0xfffe {
+        kind = ArchiveKind::Gnu;
+    }
+
+    sym_map.use_ec_map = is_ec;
+    let data = compute_member_data(
+        &mut string_table,
+        &mut sym_names,
+        kind,
+        thin,
+        &mut is_coff_archive(kind).then_some(&mut sym_map),
+        new_members,
+    )?;
 
     let sym_names = sym_names.into_inner();
 
+    let mut string_table_size: u64 = 0;
+    let mut string_table_member = None;
     let string_table = string_table.into_inner();
     if !string_table.is_empty() && !is_aix_big_archive(kind) {
-        data.insert(0, compute_string_table(&string_table));
+        let string_table_temp = compute_string_table(&string_table);
+        string_table_size = (string_table_temp.header.len()
+            + string_table_temp.data.len()
+            + string_table_temp.padding.len())
+        .try_into()
+        .unwrap();
+        string_table_member = Some(string_table_temp);
     }
 
     // We would like to detect if we need to switch to a 64-bit symbol table.
-    let mut last_member_end_offset = if is_aix_big_archive(kind) {
-        u64::try_from(std::mem::size_of::<big_archive::FixLenHdr>()).unwrap()
-    } else {
-        8
-    };
-    let mut last_member_header_offset = last_member_end_offset;
+    let mut last_member_end_offset = 0;
+    let mut last_member_header_offset = 0;
     let mut num_syms = 0;
+    let mut num_syms32: u64 = 0; // Store symbol number of 32-bit member files.
+
     for m in &data {
         // Record the start of the member's offset
+        last_member_end_offset += m.pre_head_pad_size;
         last_member_header_offset = last_member_end_offset;
         // Account for the size of each part associated with the member.
         last_member_end_offset +=
             u64::try_from(m.header.len() + m.data.len() + m.padding.len()).unwrap();
         num_syms += u64::try_from(m.symbols.len()).unwrap();
+
+        // AIX big archive files may contain two global symbol tables. The
+        // first global symbol table locates 32-bit file members that define global
+        // symbols; the second global symbol table does the same for 64-bit file
+        // members. As a big archive can have both 32-bit and 64-bit file members,
+        // we need to know the number of symbols in each symbol table individually.
+        if is_aix_big_archive(kind) && !(m.object_reader.is_64_bit_object_file)(m.data) {
+            num_syms32 = num_syms32
+                .checked_add(m.symbols.len().try_into().unwrap())
+                .unwrap();
+        }
     }
+
+    let mut maybe_headers_size = None;
 
     // The symbol table is put at the end of the big archive file. The symbol
     // table is at the start of the archive file for other archive formats.
-    if !is_aix_big_archive(kind) {
+    if !is_64bit_kind(kind) {
         // We assume 32-bit offsets to see if 32-bit symbols are possible or not.
-        let (symtab_size, _pad) = compute_symbol_table_size_and_pad(kind, num_syms, 4, &sym_names);
-        last_member_header_offset += {
-            // FIXME avoid allocating memory here
-            let mut tmp = Cursor::new(vec![]);
-            write_symbol_table_header(&mut tmp, kind, symtab_size, 0).unwrap();
-            u64::try_from(tmp.into_inner().len()).unwrap()
-        } + symtab_size;
+        maybe_headers_size = Some(compute_headers_size(
+            kind,
+            data.len(),
+            string_table_size,
+            num_syms,
+            sym_names.len().try_into().unwrap(),
+            is_coff_archive(kind).then_some(&sym_map),
+        )?);
 
         // The SYM64 format is used when an archive's member offsets are larger than
         // 32-bits can hold. The need for this shift in format is detected by
@@ -635,12 +898,13 @@ pub fn write_archive_to_stream<W: Write + Seek>(
         // If LastMemberHeaderOffset isn't going to fit in a 32-bit varible we need
         // to switch to 64-bit. Note that the file can be larger than 4GB as long as
         // the last member starts before the 4GB offset.
-        if last_member_header_offset >= SYM64_THRESHOLD {
+        if maybe_headers_size.unwrap() + last_member_header_offset >= SYM64_THRESHOLD {
             if kind == ArchiveKind::Darwin {
                 kind = ArchiveKind::Darwin64;
             } else {
                 kind = ArchiveKind::Gnu64;
             }
+            maybe_headers_size = None;
         }
     }
 
@@ -652,8 +916,46 @@ pub fn write_archive_to_stream<W: Write + Seek>(
         write!(w, "!<arch>\n")?;
     }
 
+    let headers_size;
     if !is_aix_big_archive(kind) {
-        write_symbol_table(w, kind, &data, &sym_names, 0)?;
+        headers_size = if let Some(headers_size) = maybe_headers_size {
+            headers_size
+        } else {
+            compute_headers_size(
+                kind,
+                data.len(),
+                string_table_size,
+                num_syms,
+                sym_names.len().try_into().unwrap(),
+                is_coff_archive(kind).then_some(&sym_map),
+            )?
+        };
+        write_symbol_table(
+            w,
+            kind,
+            &data,
+            &sym_names,
+            headers_size,
+            num_syms,
+            0,
+            0,
+            false,
+        )?;
+
+        if is_coff_archive(kind) {
+            write_symbol_map(w, kind, &data, &sym_map, headers_size)?;
+        }
+
+        if string_table_size > 0 {
+            let string_table_member = string_table_member.unwrap();
+            w.write_all(&string_table_member.header)?;
+            w.write_all(string_table_member.data)?;
+            w.write_all(string_table_member.padding)?;
+        }
+
+        if !sym_map.ec_map.is_empty() {
+            write_ec_symbols(w, &sym_map)?;
+        }
 
         for m in data {
             w.write_all(&m.header)?;
@@ -661,6 +963,10 @@ pub fn write_archive_to_stream<W: Write + Seek>(
             w.write_all(m.padding)?;
         }
     } else {
+        headers_size = u64::try_from(std::mem::size_of::<big_archive::FixLenHdr>()).unwrap();
+        last_member_end_offset += headers_size;
+        last_member_header_offset += headers_size;
+
         // For the big archive (AIX) format, compute a table of member names and
         // offsets, used in the member table.
         let mut member_table_name_str_tbl_size = 0;
@@ -673,12 +979,12 @@ pub fn write_archive_to_stream<W: Write + Seek>(
         for i in 0..new_members.len() {
             let member = &new_members[i];
             member_table_name_str_tbl_size += member.member_name.len() + 1;
+            member_end_offset += data[i].pre_head_pad_size;
             member_offsets.push(member_end_offset);
             member_names.push(&member.member_name);
             // File member name ended with "`\n". The length is included in
             // BigArMemHdrType.
-            member_end_offset += u64::try_from(std::mem::size_of::<big_archive::BigArMemHdrType>())
-                .unwrap()
+            member_end_offset += BIG_AR_MEM_HDR_SIZE
                 + align_to(u64::try_from(data[i].data.len()).unwrap(), 2)
                 + align_to(u64::try_from(member.member_name.len()).unwrap(), 2);
         }
@@ -687,16 +993,52 @@ pub fn write_archive_to_stream<W: Write + Seek>(
         let member_table_size =
             u64::try_from(20 + 20 * member_offsets.len() + member_table_name_str_tbl_size).unwrap();
 
-        let global_symbol_offset = if num_syms > 0 {
-            last_member_end_offset
-                + align_to(
-                    u64::try_from(std::mem::size_of::<big_archive::BigArMemHdrType>()).unwrap()
-                        + member_table_size,
-                    2,
-                )
+        let mut sym_names32 = Cursor::new(Vec::new());
+        let mut sym_names64 = Cursor::new(Vec::new());
+
+        if num_syms > 0 {
+            // Generate the symbol names for the members.
+            for m in &data {
+                write_symbols(
+                    m.data,
+                    0,
+                    if (m.object_reader.is_64_bit_object_file)(m.data) {
+                        &mut sym_names64
+                    } else {
+                        &mut sym_names32
+                    },
+                    &mut None,
+                    m.object_reader,
+                )?;
+            }
+        }
+
+        let member_table_end_offset =
+            last_member_end_offset + align_to(BIG_AR_MEM_HDR_SIZE + member_table_size, 2);
+
+        // In AIX OS, The 'GlobSymOffset' field in the fixed-length header contains
+        // the offset to the 32-bit global symbol table, and the 'GlobSym64Offset'
+        // contains the offset to the 64-bit global symbol table.
+        let global_symbol_offset = if num_syms32 > 0 {
+            member_table_end_offset
         } else {
             0
         };
+
+        let mut global_symbol_offset64 = 0;
+        let num_syms64 = num_syms - num_syms32;
+        if num_syms64 > 0 {
+            if global_symbol_offset == 0 {
+                global_symbol_offset64 = member_table_end_offset;
+            } else {
+                // If there is a global symbol table for 32-bit members,
+                // the 64-bit global symbol table is after the 32-bit one.
+                global_symbol_offset64 = global_symbol_offset
+                    + BIG_AR_MEM_HDR_SIZE
+                    + (num_syms32 + 1) * 8
+                    + align_to(sym_names32.get_ref().len().try_into().unwrap(), 2);
+            }
+        }
 
         // Fixed Sized Header.
         // Offset to member table
@@ -711,23 +1053,15 @@ pub fn write_archive_to_stream<W: Write + Seek>(
         )?;
         // If there are no file members in the archive, there will be no global
         // symbol table.
-        write!(
-            w,
-            "{:<20}",
-            if !new_members.is_empty() {
-                global_symbol_offset
-            } else {
-                0
-            }
-        )?;
-        // Offset to 64 bits global symbol table - Not supported yet
-        write!(w, "{:<20}", 0)?;
+        write!(w, "{:<20}", global_symbol_offset)?;
+        write!(w, "{:<20}", global_symbol_offset64)?;
         // Offset to first archive member
         write!(
             w,
             "{:<20}",
             if !new_members.is_empty() {
                 u64::try_from(std::mem::size_of::<big_archive::FixLenHdr>()).unwrap()
+                    + data[0].pre_head_pad_size
             } else {
                 0
             }
@@ -746,6 +1080,12 @@ pub fn write_archive_to_stream<W: Write + Seek>(
         write!(w, "{:<20}", 0)?;
 
         for m in &data {
+            write!(
+                w,
+                "{nil:\0<pad$}",
+                nil = "",
+                pad = usize::try_from(m.pre_head_pad_size).unwrap()
+            )?;
             w.write_all(&m.header)?;
             w.write_all(m.data)?;
             if m.data.len() % 2 != 0 {
@@ -764,7 +1104,11 @@ pub fn write_archive_to_stream<W: Write + Seek>(
                 0,
                 member_table_size,
                 last_member_header_offset,
-                global_symbol_offset,
+                if global_symbol_offset != 0 {
+                    global_symbol_offset
+                } else {
+                    global_symbol_offset64
+                },
             )?;
             write!(w, "{:<20}", member_offsets.len())?; // Number of members
             for member_offset in member_offsets {
@@ -781,8 +1125,42 @@ pub fn write_archive_to_stream<W: Write + Seek>(
                 w.write_all(&[0])?;
             }
 
-            if num_syms > 0 {
-                write_symbol_table(w, kind, &data, &sym_names, last_member_end_offset)?;
+            // Write global symbol table for 32-bit file members.
+            if global_symbol_offset != 0 {
+                write_symbol_table(
+                    w,
+                    kind,
+                    &data,
+                    sym_names32.get_ref(),
+                    headers_size,
+                    num_syms32,
+                    last_member_end_offset,
+                    global_symbol_offset64,
+                    false,
+                )?;
+                // Add padding between the symbol tables, if needed.
+                if global_symbol_offset64 != 0 && (sym_names32.get_ref().len() % 2) != 0 {
+                    w.write_all(&[0])?;
+                }
+            }
+
+            // Write global symbol table for 64-bit file members.
+            if global_symbol_offset64 != 0 {
+                write_symbol_table(
+                    w,
+                    kind,
+                    &data,
+                    sym_names64.get_ref(),
+                    headers_size,
+                    num_syms64,
+                    if global_symbol_offset != 0 {
+                        global_symbol_offset
+                    } else {
+                        last_member_end_offset
+                    },
+                    0,
+                    true,
+                )?;
             }
         }
     }

--- a/src/coff_import_file.rs
+++ b/src/coff_import_file.rs
@@ -1,0 +1,9 @@
+// Derived from code in LLVM, which is:
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+pub(crate) const IMPORT_DESCRIPTOR_PREFIX: &[u8] = b"__IMPORT_DESCRIPTOR_";
+pub(crate) const NULL_IMPORT_DESCRIPTOR_SYMBOL_NAME: &[u8] = b"__NULL_IMPORT_DESCRIPTOR";
+pub(crate) const NULL_THUNK_DATA_PREFIX: &[u8] = b"\x7f";
+pub(crate) const NULL_THUNK_DATA_SUFFIX: &[u8] = b"_NULL_THUNK_DATA";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,44 @@
+#![allow(clippy::too_many_arguments)]
+// We are writing a very specific, well defined format, so it makes it easier to
+// see exactly what is being written if we explicitly write out `\n` instead of
+// hoping somebody notices the `writeln!` instead of `write!`.
+#![allow(clippy::write_with_newline)]
+
 mod alignment;
 mod archive;
 mod archive_writer;
+mod coff_import_file;
+mod math_extras;
+mod object_reader;
 
 pub use archive::ArchiveKind;
-pub use archive_writer::{get_native_object_symbols, write_archive_to_stream, NewArchiveMember};
+pub use archive_writer::{write_archive_to_stream, NewArchiveMember};
+
+pub type GetSymbolsFn =
+    fn(buf: &[u8], f: &mut dyn FnMut(&[u8]) -> std::io::Result<()>) -> std::io::Result<bool>;
+pub type Is64BitObjectFileFn = fn(buf: &[u8]) -> bool;
+pub type IsECObjectFileFn = fn(buf: &[u8]) -> bool;
+pub type GetXCoffMemberAlignmentFn = fn(buf: &[u8]) -> u32;
+
+/// Helper struct to query object file information from members.
+pub struct ObjectReader {
+    /// Iterates over the symbols in the object file.
+    pub get_symbols: GetSymbolsFn,
+    /// Returns true if the object file is 64-bit.
+    /// Note that this should match LLVM's `SymbolicFile::is64Bit`, which
+    /// considers all COFF files to be 32-bit.
+    pub is_64_bit_object_file: Is64BitObjectFileFn,
+    /// Returns true if the object file is an EC (that is, an Arm64EC or x64)
+    /// object file
+    pub is_ec_object_file: IsECObjectFileFn,
+    /// Returns the member alignment of an XCoff object file.
+    pub get_xcoff_member_alignment: GetXCoffMemberAlignmentFn,
+}
+
+/// Default implementation of [ObjectReader] that uses the `object` crate.
+pub const DEFAULT_OBJECT_READER: ObjectReader = ObjectReader {
+    get_symbols: object_reader::get_native_object_symbols,
+    is_64_bit_object_file: object_reader::is_64_bit_symbolic_file,
+    is_ec_object_file: object_reader::is_ec_object,
+    get_xcoff_member_alignment: object_reader::get_member_alignment,
+};

--- a/src/math_extras.rs
+++ b/src/math_extras.rs
@@ -1,0 +1,15 @@
+// Derived from code in LLVM, which is:
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+pub(crate) fn align_to_power_of2(value: u64, align: u64) -> u64 {
+    assert!(
+        align != 0 && (align & (align - 1)) == 0,
+        "Align must be a power of 2"
+    );
+    // Replace unary minus to avoid compilation error on Windows:
+    // "unary minus operator applied to unsigned type, result still unsigned"
+    let neg_align = !(align) + 1;
+    (value + align - 1) & neg_align
+}

--- a/src/object_reader.rs
+++ b/src/object_reader.rs
@@ -1,0 +1,182 @@
+// Derived from code in LLVM, which is:
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//! Default implementation of [crate::ObjectReader] that uses the `object` crate.
+
+use std::{io, mem::offset_of};
+
+use object::{xcoff, Object, ObjectSymbol};
+
+fn is_archive_symbol(sym: &object::read::Symbol<'_, '_>) -> bool {
+    // FIXME Use a better equivalent of LLVM's SymbolRef::SF_FormatSpecific
+    if sym.kind() == object::SymbolKind::Null
+        || sym.kind() == object::SymbolKind::File
+        || sym.kind() == object::SymbolKind::Section
+    {
+        return false;
+    }
+    if !sym.is_global() {
+        return false;
+    }
+    if sym.is_undefined() {
+        return false;
+    }
+    true
+}
+
+pub fn get_native_object_symbols(
+    buf: &[u8],
+    f: &mut dyn FnMut(&[u8]) -> io::Result<()>,
+) -> io::Result<bool> {
+    // FIXME match what LLVM does
+
+    match object::File::parse(buf) {
+        Ok(file) => {
+            for sym in file.symbols() {
+                if !is_archive_symbol(&sym) {
+                    continue;
+                }
+                f(sym.name_bytes().expect("FIXME"))?;
+            }
+            Ok(true)
+        }
+        Err(_) => Ok(false),
+    }
+}
+
+pub fn is_ec_object(obj: &[u8]) -> bool {
+    match object::FileKind::parse(obj) {
+        Ok(object::FileKind::Coff) => {
+            u16::from_le_bytes([obj[0], obj[1]]) != object::pe::IMAGE_FILE_MACHINE_ARM64
+        }
+        Ok(object::FileKind::CoffImport) => {
+            // COFF Import Header is:
+            // sig1: u16
+            // sig2: u16
+            // version: u16
+            // machine: u16
+            u16::from_le_bytes([obj[6], obj[7]]) != object::pe::IMAGE_FILE_MACHINE_ARM64
+        }
+        _ => false,
+    }
+}
+
+pub fn is_64_bit_symbolic_file(obj: &[u8]) -> bool {
+    object::FileKind::parse(obj).is_ok_and(|kind| match kind {
+        object::FileKind::Elf64
+        | object::FileKind::MachO64
+        | object::FileKind::Pe64
+        | object::FileKind::Xcoff64
+        | object::FileKind::MachOFat64 => true,
+        object::FileKind::Elf32
+        | object::FileKind::MachO32
+        | object::FileKind::Pe32
+        | object::FileKind::Xcoff32
+        | object::FileKind::MachOFat32
+        | object::FileKind::Coff
+        | object::FileKind::CoffBig
+        | object::FileKind::CoffImport => false,
+        _ => panic!("Unexpected file kind"),
+    })
+}
+
+// Log2 of PAGESIZE(4096) on an AIX system.
+const LOG2_OF_AIXPAGE_SIZE: u32 = 12;
+
+// In the AIX big archive format, since the data content follows the member file
+// name, if the name ends on an odd byte, an extra byte will be added for
+// padding. This ensures that the data within the member file starts at an even
+// byte.
+const MIN_BIG_ARCHIVE_MEM_DATA_ALIGN: u32 = 2;
+
+fn get_aux_max_alignment<AuxiliaryHeader: object::read::xcoff::AuxHeader>(
+    aux_header_size: u16,
+    aux_header: Option<&AuxiliaryHeader>,
+    log_2_of_max_align: u32,
+    offset_of_modtype: u16,
+) -> u32 {
+    // If the member doesn't have an auxiliary header, it isn't a loadable object
+    // and so it just needs aligning at the minimum value.
+    let Some(aux_header) = aux_header else {
+        return MIN_BIG_ARCHIVE_MEM_DATA_ALIGN;
+    };
+
+    // If the auxiliary header does not have both MaxAlignOfData and
+    // MaxAlignOfText field, it is not a loadable shared object file, so align at
+    // the minimum value. The 'ModuleType' member is located right after
+    // 'MaxAlignOfData' in the AuxiliaryHeader.
+    if aux_header_size < offset_of_modtype {
+        return MIN_BIG_ARCHIVE_MEM_DATA_ALIGN;
+    }
+
+    // If the XCOFF object file does not have a loader section, it is not
+    // loadable, so align at the minimum value.
+    if aux_header.o_snloader() == 0 {
+        return MIN_BIG_ARCHIVE_MEM_DATA_ALIGN;
+    }
+
+    // The content of the loadable member file needs to be aligned at MAX(maximum
+    // alignment of .text, maximum alignment of .data) if there are both fields.
+    // If the desired alignment is > PAGESIZE, 32-bit members are aligned on a
+    // word boundary, while 64-bit members are aligned on a PAGESIZE(2^12=4096)
+    // boundary.
+    let log_2_of_align = u32::from(std::cmp::max(
+        aux_header.o_algntext(),
+        aux_header.o_algndata(),
+    ));
+    1 << (if log_2_of_align > LOG2_OF_AIXPAGE_SIZE {
+        log_2_of_max_align
+    } else {
+        log_2_of_align
+    })
+}
+
+// AIX big archives may contain shared object members. The AIX OS requires these
+// members to be aligned if they are 64-bit and recommends it for 32-bit
+// members. This ensures that when these members are loaded they are aligned in
+// memory.
+pub fn get_member_alignment(obj: &[u8]) -> u32 {
+    use object::read::xcoff::FileHeader;
+
+    // If the desired alignment is > PAGESIZE, 32-bit members are aligned on a
+    // word boundary, while 64-bit members are aligned on a PAGESIZE boundary.
+    match object::FileKind::parse(obj) {
+        Ok(object::FileKind::Xcoff64) => {
+            let mut offset = 0;
+            let Ok(header) = xcoff::FileHeader64::parse(obj, &mut offset) else {
+                return MIN_BIG_ARCHIVE_MEM_DATA_ALIGN;
+            };
+            let Ok(aux_header) = header.aux_header(obj, &mut offset) else {
+                return MIN_BIG_ARCHIVE_MEM_DATA_ALIGN;
+            };
+            get_aux_max_alignment(
+                header.f_opthdr(),
+                aux_header,
+                LOG2_OF_AIXPAGE_SIZE,
+                offset_of!(object::xcoff::AuxHeader64, o_modtype)
+                    .try_into()
+                    .unwrap(),
+            )
+        }
+        Ok(object::FileKind::Xcoff32) => {
+            let mut offset = 0;
+            let Ok(header) = object::xcoff::FileHeader32::parse(obj, &mut offset) else {
+                return MIN_BIG_ARCHIVE_MEM_DATA_ALIGN;
+            };
+            let Ok(aux_header) = header.aux_header(obj, &mut offset) else {
+                return MIN_BIG_ARCHIVE_MEM_DATA_ALIGN;
+            };
+            get_aux_max_alignment(
+                header.f_opthdr(),
+                aux_header,
+                2,
+                offset_of!(object::xcoff::AuxHeader32, o_modtype)
+                    .try_into()
+                    .unwrap(),
+            )
+        }
+        _ => MIN_BIG_ARCHIVE_MEM_DATA_ALIGN,
+    }
+}

--- a/tests/multiple_objects.rs
+++ b/tests/multiple_objects.rs
@@ -1,4 +1,4 @@
-use object::{write, Architecture};
+use object::write;
 
 mod common;
 
@@ -9,25 +9,22 @@ mod common;
 fn basic_multiple_objects() {
     common::generate_archive_and_compare(
         "basic_multiple_objects",
-        |architecture, endianness, binary_format| {
+        |architecture, subarch, endianness, binary_format| {
             let mut object1 = write::Object::new(binary_format, architecture, endianness);
-            // FIXME: Need 64-bit Big AIX symbol table support to match llvm-ar.
-            if architecture != Architecture::PowerPc64 {
-                common::add_file_with_functions_to_object(
-                    &mut object1,
-                    b"file1.c",
-                    &[b"func1", b"func2", b"func_overlapping"],
-                );
-            }
+            object1.set_sub_architecture(subarch);
+            common::add_file_with_functions_to_object(
+                &mut object1,
+                b"file1.c",
+                &[b"func1", b"func2", b"func_overlapping"],
+            );
 
             let mut object2 = write::Object::new(binary_format, architecture, endianness);
-            if architecture != Architecture::PowerPc64 {
-                common::add_file_with_functions_to_object(
-                    &mut object2,
-                    b"file2.c",
-                    &[b"func3", b"func4", b"func_overlapping"],
-                );
-            }
+            object2.set_sub_architecture(subarch);
+            common::add_file_with_functions_to_object(
+                &mut object2,
+                b"file2.c",
+                &[b"func3", b"func4", b"func_overlapping"],
+            );
 
             vec![
                 ("file1.o", object1.write().unwrap()),
@@ -44,17 +41,14 @@ fn basic_multiple_objects() {
 fn multiple_objects_same_name() {
     common::generate_archive_and_compare(
         "multiple_objects_same_name",
-        |architecture, endianness, binary_format| {
+        |architecture, subarch, endianness, binary_format| {
             let mut object1 = write::Object::new(binary_format, architecture, endianness);
-            // FIXME: Need 64-bit Big AIX symbol table support to match llvm-ar.
-            if architecture != Architecture::PowerPc64 {
-                common::add_file_with_functions_to_object(&mut object1, b"file1.c", &[b"func1"]);
-            }
+            object1.set_sub_architecture(subarch);
+            common::add_file_with_functions_to_object(&mut object1, b"file1.c", &[b"func1"]);
 
             let mut object2 = write::Object::new(binary_format, architecture, endianness);
-            if architecture != Architecture::PowerPc64 {
-                common::add_file_with_functions_to_object(&mut object2, b"file2.c", &[b"func2"]);
-            }
+            object2.set_sub_architecture(subarch);
+            common::add_file_with_functions_to_object(&mut object2, b"file2.c", &[b"func2"]);
 
             vec![
                 ("1/file.o", object1.write().unwrap()),


### PR DESCRIPTION
Syncs to LLVM 18.1.3:
* Adds support for COFF.
* Adds support for Arm64EC.
* Adds support for AIX symbol tables.

Other changes:
* Move LLVM C++ files into `reference` directory, to make it clear that they aren't built.
* Moved all object parsing into a new `object_reader` module, and replaced the single `get_symbol` callback with an `ObjectReader` struct that has all the callbacks we require for reading object files.
* Bumped `object` to latest.
* Synced round-trip tests with `object`.
* Requires beta Rust toolchain (1.78) since this has LLVM 18.
* Got clippy clean and added clippy to CI.

Fixes #9