### PR TITLE
Add explicit lifetime parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ object = { version = "0.35.0", default-features = false, features = ["std", "rea
 cargo-binutils = "0.3.6"
 object = { version = "0.35.0", default-features = false, features = ["write", "xcoff"] }
 pretty_assertions = "1.4.0"
+
+[lints.rust]
+rust_2018_idioms = { level = "deny" }

--- a/src/archive_writer.rs
+++ b/src/archive_writer.rs
@@ -475,7 +475,7 @@ fn write_symbol_table<W: Write + Seek>(
 fn write_symbol_map<W: Write + Seek>(
     w: &mut W,
     kind: ArchiveKind,
-    members: &[MemberData],
+    members: &[MemberData<'_>],
     sym_map: &SymMap,
     members_offset: u64,
 ) -> io::Result<()> {

--- a/src/coff_import_file.rs
+++ b/src/coff_import_file.rs
@@ -246,7 +246,7 @@ impl<'a> ObjectFactory<'a> {
     /// reference to the terminators and contains the library name (entry) for the
     /// import name table.  It will force the linker to construct the necessary
     /// structure to import symbols from the DLL.
-    fn create_import_descriptor(&self) -> Result<NewArchiveMember> {
+    fn create_import_descriptor(&self) -> Result<NewArchiveMember<'_>> {
         let mut buffer = Vec::new();
 
         const NUMBER_OF_SECTIONS: usize = 2;
@@ -460,7 +460,7 @@ impl<'a> ObjectFactory<'a> {
     /// Creates a NULL import descriptor.  This is a small object file whcih
     /// contains a NULL import descriptor.  It is used to terminate the imports
     /// from a specific DLL.
-    fn create_null_import_descriptor(&self) -> Result<NewArchiveMember> {
+    fn create_null_import_descriptor(&self) -> Result<NewArchiveMember<'_>> {
         let mut buffer = Vec::new();
 
         const NUMBER_OF_SECTIONS: usize = 1;
@@ -542,7 +542,7 @@ impl<'a> ObjectFactory<'a> {
     /// Create a NULL Thunk Entry.  This is a small object file which contains a
     /// NULL Import Address Table entry and a NULL Import Lookup Table Entry.  It
     /// is used to terminate the IAT and ILT.
-    fn create_null_thunk(&self) -> Result<NewArchiveMember> {
+    fn create_null_thunk(&self) -> Result<NewArchiveMember<'_>> {
         let mut buffer = Vec::new();
 
         const NUMBER_OF_SECTIONS: usize = 2;
@@ -658,7 +658,7 @@ impl<'a> ObjectFactory<'a> {
         name_type: ImportNameType,
         export_name: Option<&str>,
         machine: MachineTypes,
-    ) -> Result<NewArchiveMember> {
+    ) -> Result<NewArchiveMember<'_>> {
         let mut imp_size = self.import_name.len() + sym.len() + 2; // +2 for NULs
         if let Some(export_name) = export_name {
             imp_size += export_name.len() + 1;
@@ -704,7 +704,7 @@ impl<'a> ObjectFactory<'a> {
         weak: &str,
         imp: bool,
         machine: MachineTypes,
-    ) -> Result<NewArchiveMember> {
+    ) -> Result<NewArchiveMember<'_>> {
         let mut buffer = Vec::new();
         const NUMBER_OF_SECTIONS: usize = 1;
         const NUMBER_OF_SYMBOLS: usize = 5;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -367,7 +367,7 @@ where
 }
 
 pub fn add_file_with_functions_to_object(
-    object: &mut Object,
+    object: &mut Object<'_>,
     file_name: &[u8],
     func_names: &[&[u8]],
 ) {


### PR DESCRIPTION
When I tried to use a local copy of `ar_archive_writer` to patch rustc, I was getting the `hidden lifetime parameters in types are deprecated` error.

This change adds explicit lifetime parameters at every place where this error was raised.