### PR TITLE
Add support for creating archives with members from an import library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ repository = "https://github.com/rust-lang/ar_archive_writer"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-object = { version = "0.35.0", default-features = false, features = ["std", "read"] }
+object = { version = "0.36.2", default-features = false, features = ["std", "read"] }
 
 [dev-dependencies]
 cargo-binutils = "0.3.6"
-object = { version = "0.35.0", default-features = false, features = ["write", "xcoff"] }
+object = { version = "0.36.2", default-features = false, features = ["write", "xcoff"] }
 pretty_assertions = "1.4.0"
 
 [lints.rust]

--- a/src/coff_import_file.rs
+++ b/src/coff_import_file.rs
@@ -42,7 +42,10 @@ macro_rules! u32 {
 }
 
 // Derived from COFFImportFile::printSymbolName and COFFImportFile::symbol_end.
-fn get_short_import_symbol(buf: &[u8], f: &mut dyn FnMut(&[u8]) -> Result<()>) -> Result<bool> {
+pub(crate) fn get_short_import_symbol(
+    buf: &[u8],
+    f: &mut dyn FnMut(&[u8]) -> Result<()>,
+) -> Result<bool> {
     let mut offset = 0;
     let header = ImportObjectHeader::parse(buf, &mut offset).map_err(Error::other)?;
     let data = header.parse_data(buf, &mut offset).map_err(Error::other)?;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -107,10 +107,10 @@ fn run_llvm_ar(
 
 /// Creates an archive with the given objects using `llvm-ar`.
 /// The generated archive is written to disk as `output_llvm_ar.a`.
-pub fn create_archive_with_llvm_ar<'a>(
+pub fn create_archive_with_llvm_ar<'name, 'data>(
     tmpdir: &Path,
     archive_kind: ArchiveKind,
-    input_objects: impl IntoIterator<Item = (&'static str, &'a [u8])>,
+    input_objects: impl IntoIterator<Item = (&'name str, &'data [u8])>,
     thin: bool,
     is_ec: bool,
 ) -> Vec<u8> {
@@ -140,10 +140,10 @@ pub fn create_archive_with_llvm_ar<'a>(
 
 /// Creates an archive with the given objects using `ar_archive_writer`.
 /// The generated archive is written to disk as `output_ar_archive_writer.a`.
-pub fn create_archive_with_ar_archive_writer<'a>(
+pub fn create_archive_with_ar_archive_writer<'name, 'data>(
     tmpdir: &Path,
     archive_kind: ArchiveKind,
-    input_objects: impl IntoIterator<Item = (&'static str, &'a [u8])>,
+    input_objects: impl IntoIterator<Item = (&'name str, &'data [u8])>,
     thin: bool,
     is_ec: bool,
 ) -> Vec<u8> {

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -49,12 +49,6 @@ fn round_trip_and_diff(
         let output_archive =
             read::archive::ArchiveFile::parse(output_archive_bytes.as_slice()).unwrap();
         let mut members = output_archive.members();
-        if is_ec && archive_kind == ArchiveKind::Coff {
-            // FIXME: Skip the EC Symbol Table, since `object` doesn't correctly
-            // handle it as a special member.
-            // Fix in object: https://github.com/gimli-rs/object/pull/669
-            members.next().unwrap().unwrap();
-        }
         let output_member = members.next().unwrap().unwrap();
         if archive_kind != ArchiveKind::Coff {
             assert_eq!(output_member.name(), b"input.o");


### PR DESCRIPTION
Currently the default object reader can't handle getting symbols from an import library archive member, and so symbols from such members are not included in the symbol table for the archive, resulting in linker failures.

This change:
* Adds a fallback to the default object reader to try parsing a member as an import library if normal parsing fails.
* Adds a test to wrap an import library in an archive (and compare to lib.exe).
* Bumps the version of `object` so that the EC Symbol Table is correct skipped.