### PR TITLE
Make the null import descriptor name unique to the import library

### DIFF
--- a/src/archive_writer.rs
+++ b/src/archive_writer.rs
@@ -542,7 +542,7 @@ fn write_ec_symbols<W: Write + Seek>(w: &mut W, sym_map: &SymMap) -> io::Result<
 
 fn is_import_descriptor(name: &[u8]) -> bool {
     name.starts_with(coff_import_file::IMPORT_DESCRIPTOR_PREFIX)
-        || name == coff_import_file::NULL_IMPORT_DESCRIPTOR_SYMBOL_NAME
+        || name.starts_with(coff_import_file::NULL_IMPORT_DESCRIPTOR_SYMBOL_NAME)
         || (name.starts_with(coff_import_file::NULL_THUNK_DATA_PREFIX)
             && name.ends_with(coff_import_file::NULL_THUNK_DATA_SUFFIX))
 }


### PR DESCRIPTION
It turns out that the name of the null import descriptor is less special than I had assumed. We can use anything. So this makes the null import descriptor incorporate the name of the library to avoid any conflicts when using `/WHOLEARCHIVE`. This is done only if the `whole_archive_compat` option is set.

I've tested this locally with different targets and both MSVC and LLVM can use the import libraries it generates. Also this approach passes [Rust's CI](https://github.com/rust-lang/rust/pull/129257).

Closes #22 because we reuse the same flag for essentially the same purpose and renaming an argument is not a semver break.