### PR TITLE
Don't raise an error when using non-Arm64EC mangled names if EXPORTAS is set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ar_archive_writer"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A writer for object file ar archives"

--- a/src/coff_import_file.rs
+++ b/src/coff_import_file.rs
@@ -994,6 +994,11 @@ pub fn write_import_library<W: Write + Seek>(
                         }
                         name = Cow::Owned(mangled_name);
                     }
+                    Err(_) if !e.noname && export_name.is_none() => {
+                        return Err(Error::other(format!(
+                            "Functions on Arm64EC must use the Arm64EC mangling scheme, but the function \"{name}\" does not. Either use the Arm64EC mangled name or set the `export_name`."
+                        )));
+                    }
                     Ok(None) if !e.noname && export_name.is_none() => {
                         let demangled_name = get_arm64ec_demangled_function_name(&name)
                             .ok_or_else(|| {
@@ -1002,12 +1007,7 @@ pub fn write_import_library<W: Write + Seek>(
                         name_type = ImportNameType::NameExportas;
                         export_name = Some(Cow::Owned(demangled_name));
                     }
-                    Ok(None) => {}
-                    Err(_) => {
-                        return Err(Error::other(format!(
-                            "Functions on Arm64EC must use the Arm64EC mangling scheme, but the function \"{name}\" does not."
-                        )));
-                    }
+                    _ => {}
                 }
             }
 


### PR DESCRIPTION
With version 0.5.0, `ar_archive_writer` lost the ability to Arm64EC mangle C++ names.

However, with how `ar_archive_writer` is used within the Rust compiler we don't care about the Arm64EC mangled name: the final DLL only uses the unmangled name in `EXPORTAS`, therefore if we see `EXPORTAS` set then we can assume that's the correct name and ignore the error that we couldn't mangle the `name`.