### PR TITLE
Fix if-let chains for compilation on rustc v1.85

### DIFF
--- a/src/archive_writer.rs
+++ b/src/archive_writer.rs
@@ -588,11 +588,10 @@ fn write_symbols(
 
                 // If EC is enabled, then the import descriptors are NOT put into EC
                 // objects so we need to copy them to the EC map manually.
-                if let Some(ec_map) = &mut ec_map
-                    && is_import_descriptor(name)
-                {
-                    ec_map.insert(name.to_vec().into_boxed_slice(), index);
-                }
+                ec_map.as_mut().and_then(|ec_map| {
+                    is_import_descriptor(name)
+                        .then(|| ec_map.insert(name.to_vec().into_boxed_slice(), index))
+                });
             }
         } else {
             ret.push(sym_names.stream_position()?);

--- a/src/coff_import_file.rs
+++ b/src/coff_import_file.rs
@@ -138,12 +138,9 @@ fn set_name_to_string_table_entry(symbol: &mut ImageSymbol, offset: usize) {
 
 fn apply_name_type(import_type: ImportNameType, name: &str) -> &str {
     fn ltrim1<'a>(name: &'a str, chars: &str) -> &'a str {
-        if let Some((first_char, rest)) = name.split_at_checked(1)
-            && chars.contains(first_char)
-        {
-            return rest;
-        }
-        name
+        name.split_at_checked(1)
+            .and_then(|(first_char, rest)| chars.contains(first_char).then_some(rest))
+            .unwrap_or(name)
     }
 
     match import_type {


### PR DESCRIPTION
if-let chains are unstable until 1.88, so rewrite in a more functional way that
keeps the same logic and allows compilation on earlier rustc versions.