### PR TITLE
Use package.include to remove the reference implementation which isn't necessary for building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "A writer for object file ar archives"
 keywords = ["ar", "archive"]
 readme = "Readme.md"
 repository = "https://github.com/rust-lang/ar_archive_writer"
+include = ["/src", "/LICENSE.txt", "/Readme.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This decreases the packaged size to less than half:

|                        | # of files | uncompressed     | compressed      |
| ---------------------- | ---------- | ---------------- | --------------- |
| before                 | 35         | 355.5KiB         | 82.9KiB         |
| with `package.include` | 15 (42.9%) | 122.9KiB (34.6%) | 30.1KiB (36.3%) |
| with tests¹            | 20 (57.1%) | 166.5KiB (46.9%) | 37.4KiB (45.1%) |

And beyond that allows easier dependency reviews (though that is in this
case much less important since everything `rust-lang` is likely trusted
anyways)

This now includes (output from `cargo package --list`):
```
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE.txt
Readme.md
src/alignment.rs
src/archive.rs
src/archive_writer.rs
src/coff.rs
src/coff_import_file.rs
src/lib.rs
src/mangler.rs
src/math_extras.rs
src/object_reader.rs
```

¹ Using the version below (which includes tests as well):
```rust
include = ["/src", "/tests", "/LICENSE.txt", "/Readme.md"]
```
The additionally included files would be:
```
tests/common.rs
tests/import_library.def
tests/import_library.rs
tests/multiple_objects.rs
tests/round_trip.rs
```
