### PR TITLE
add MSRV 1.88.0 to Cargo.toml, determined with "cargo msrv find"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ar_archive_writer"
 version = "0.5.1"
 edition = "2024"
+rust-version = "1.88.0"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A writer for object file ar archives"
 keywords = ["ar", "archive"]

--- a/src/archive_writer.rs
+++ b/src/archive_writer.rs
@@ -164,7 +164,7 @@ fn print_big_archive_member_header<W: Write>(
     if !name.is_empty() {
         write!(w, "{name}")?;
 
-        if name.len() % 2 != 0 {
+        if !name.len().is_multiple_of(2) {
             write!(w, "\0")?;
         }
     }


### PR DESCRIPTION
This PR fixes compile errors downstream for projects supporting older MSRV than `ar_archive_writer`. What I did:

- found out the current MSRV with [cargo-msrv](https://github.com/foresterre/cargo-msrv)
- added `rust-version` key to `Cargo.toml`
- fix clippy warning: remove manual implementation of `is_multiple_of` – https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_is_multiple_of


<details>

<summary> Output of `cargo msrv find` </summary>

```text
$ cargo msrv find
  [Meta]   cargo-msrv 0.19.3  

Compatibility Check #1: Rust 1.91.1
  [OK]     Is compatible 

Compatibility Check #2: Rust 1.88.0
  [OK]     Is compatible 

Compatibility Check #3: Rust 1.86.0
  [FAIL]   Is incompatible 
                                                                                                        
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │     Checking ar_archive_writer v0.5.1 (/home/user/ar_archive_writer)                               │
  │ error[E0658]: `let` expressions in this position are unstable                                      │
  │    --> src/archive_writer.rs:591:20                                                                │
  │     |                                                                                              │
  │ 591 |                 if let Some(ec_map) = &mut ec_map                                            │
  │     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                            │
  │     |                                                                                              │
  │     = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information │
  │                                                                                                    │
  │ error[E0658]: `let` expressions in this position are unstable                                      │
  │    --> src/coff_import_file.rs:141:12                                                              │
  │     |                                                                                              │
  │ 141 |         if let Some((first_char, rest)) = name.split_at_checked(1)                           │
  │     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                           │
  │     |                                                                                              │
  │     = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information │
  │                                                                                                    │
  │ For more information about this error, try `rustc --explain E0658`.                                │
  │ error: could not compile `ar_archive_writer` (lib) due to 2 previous errors                        │
  │                                                                                                    │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                        

Compatibility Check #4: Rust 1.87.0
  [FAIL]   Is incompatible 
                                                                                                        
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │     Checking ar_archive_writer v0.5.1 (/home/user/ar_archive_writer)                               │
  │ error[E0658]: `let` expressions in this position are unstable                                      │
  │    --> src/archive_writer.rs:591:20                                                                │
  │     |                                                                                              │
  │ 591 |                 if let Some(ec_map) = &mut ec_map                                            │
  │     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                            │
  │     |                                                                                              │
  │     = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information │
  │                                                                                                    │
  │ error[E0658]: `let` expressions in this position are unstable                                      │
  │    --> src/coff_import_file.rs:141:12                                                              │
  │     |                                                                                              │
  │ 141 |         if let Some((first_char, rest)) = name.split_at_checked(1)                           │
  │     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                           │
  │     |                                                                                              │
  │     = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information │
  │                                                                                                    │
  │ For more information about this error, try `rustc --explain E0658`.                                │
  │ error: could not compile `ar_archive_writer` (lib) due to 2 previous errors                        │
  │                                                                                                    │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                        

Result:
   Considered (min … max):   Rust 1.85.1 … Rust 1.96.0 
   Search method:            bisect                    
   MSRV:                     1.88.0                    
   Target:                   x86_64-unknown-linux-gnu  
                                                       

```

</details>

# To Do

`cargo test` fails:
```text
thread 'compare_to_lib' (553353) panicked at tests/import_library.rs:193:9:
assertion failed: `(left == right)`: Import library differs. Machine type: I386
```

However, this has already been failing on `main`.