### PR TITLE
Mark all public enums `non_exhaustive`

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -6,6 +6,7 @@
 /// Size field is 10 decimal digits long
 pub(crate) const MAX_MEMBER_SIZE: u64 = 9999999999;
 
+#[non_exhaustive]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ArchiveKind {
     Gnu,

--- a/src/coff.rs
+++ b/src/coff.rs
@@ -3,6 +3,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[repr(u16)]
 #[allow(clippy::upper_case_acronyms)]
@@ -49,6 +50,7 @@ pub fn is_64_bit(machine: MachineTypes) -> bool {
     machine == MachineTypes::AMD64 || is_any_arm64(machine)
 }
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Copy, Clone)]
 #[repr(u16)]
 pub enum ImportType {
@@ -66,6 +68,7 @@ impl From<ImportType> for u16 {
     }
 }
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Copy, Clone)]
 #[repr(u16)]
 pub enum ImportNameType {


### PR DESCRIPTION
These aren't likely to be matched on outside of this crate, but making them `non_exhaustive` makes it clear that more variants may be added in the future. Currently only `ArchiveKind` and `MachineTypes` are actually public, `non_exhaustive` has no effect within the crate.